### PR TITLE
Standardise mentions

### DIFF
--- a/assets/client.json
+++ b/assets/client.json
@@ -1,1 +1,2186 @@
-{"openapi":"3.1.0","info":{"version":"1.0.0","title":"Client to Server API"},"servers":[{"url":"https://chat.understars.dev"}],"components":{"securitySchemes":{"bearerAuth":{"type":"http","scheme":"bearer","bearerFormat":"JWT"}},"responses":{"BadRequest":{"description":"Bad request","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HttpError"}}}},"NotFound":{"description":"The requested resource was not found","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HttpError"}}}},"Unauthorised":{"description":"Unauthorised","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HttpError"}}}},"InternalServerError":{"description":"Internal server error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HttpError"}}}}},"schemas":{"HttpError":{"type":"object","properties":{"message":{"type":"string"},"code":{"type":"number"},"detail":{"type":"object","properties":{"body":{"type":"array","items":{"anyOf":[{"type":"object","properties":{"message":{"type":"string"},"code":{"type":"string"},"path":{"type":"array","items":{"type":"string"}}},"required":["message","code","path"]},{},{"type":"null"}]}},"param":{"type":"array","items":{"anyOf":[{"type":"object","properties":{"message":{"type":"string"},"code":{"type":"string"},"path":{"type":"array","items":{"type":"string"}}},"required":["message","code","path"]},{},{"type":"null"}]}},"query":{"type":"array","items":{"anyOf":[{"type":"object","properties":{"message":{"type":"string"},"code":{"type":"string"},"path":{"type":"array","items":{"type":"string"}}},"required":["message","code","path"]},{},{"type":"null"}]}}}}},"required":["message","code"]},"PublicUser":{"type":"object","properties":{"id":{"type":"string"},"name":{"type":"string"},"summary":{"type":"string"},"display_name":{"type":"string"},"domain":{"type":"string"}},"required":["id","name","summary","display_name","domain"]},"PrivateUser":{"allOf":[{"$ref":"#/components/schemas/PublicUser"},{"type":"object","properties":{"email":{"type":"string"}},"required":["email"]}]},"PublicGuildTextChannel":{"type":"object","properties":{"id":{"type":"string"},"name":{"type":"string"},"domain":{"type":"string"},"guild_id":{"type":"string"}},"required":["id","name","domain"]},"PublicGuild":{"type":"object","properties":{"id":{"type":"string"},"name":{"type":"string"},"domain":{"type":"string"},"channels":{"type":"array","items":{"$ref":"#/components/schemas/PublicGuildTextChannel"}},"roles":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"name":{"type":"string"},"allow":{"type":"array","items":{"type":"number"}},"deny":{"type":"array","items":{"type":"number"}},"guild_id":{"type":"string"}},"required":["id","name","allow","deny"]}}},"required":["id","name","domain"]},"PublicChannel":{"type":"object","properties":{"id":{"type":"string"},"name":{"type":"string"},"domain":{"type":"string"}},"required":["id","name","domain"]},"PrivateRelationship":{"type":"object","properties":{"created":{"type":"string"},"user":{"$ref":"#/components/schemas/PublicUser"},"type":{"type":"integer","enum":[0,1,2]}},"required":["created","user","type"]},"PublicAttachment":{"type":"object","properties":{"name":{"type":"string"},"hash":{"type":"string"},"type":{"type":"string"},"size":{"type":"number"},"width":{"type":["number","null"]},"height":{"type":["number","null"]}},"required":["name","hash","type","size"]},"PublicMessage":{"type":"object","properties":{"id":{"type":"string"},"content":{"type":"string"},"published":{"type":"string"},"updated":{"type":"string"},"author_id":{"type":"string"},"channel_id":{"type":"string"},"files":{"type":"array","items":{"$ref":"#/components/schemas/PublicAttachment"}}},"required":["id","content","published","updated","author_id","channel_id","files"]},"MessageCreateRequest":{"type":"object","properties":{"content":{"type":"string"},"files":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"hash":{"type":"string"}},"required":["name","hash"]}}},"minProperties":1}},"parameters":{}},"paths":{"/upload/":{"put":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"t","in":"query"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/auth/register":{"post":{"requestBody":{"content":{"application/json":{"schema":{"type":"object","properties":{"username":{"type":"string"},"password":{"type":"string"},"email":{"type":"string"},"invite":{"type":"string","description":"Instance registration invite"}},"required":["username","password"]}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{"token":{"type":"string"}},"required":["token"]}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/auth/login":{"post":{"requestBody":{"content":{"application/json":{"schema":{"type":"object","properties":{"username":{"type":"string"},"password":{"type":"string"}},"required":["username","password"]}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{"token":{"type":"string"},"user":{"$ref":"#/components/schemas/PublicUser"}},"required":["token","user"]}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/invite/{invite_code}":{"post":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"invite_code","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}},"delete":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"invite_code","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/users/@me/":{"get":{"security":[{"bearerAuth":[]}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PrivateUser"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}},"patch":{"security":[{"bearerAuth":[]}],"requestBody":{"content":{"application/json":{"schema":{"type":"object","properties":{"display_name":{"type":"string"},"summary":{"type":"string"},"current_password":{"type":"string"},"password":{"type":"string"},"email":{"type":"string","format":"email"}},"additionalProperties":false}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/users/@me/guild/":{"get":{"security":[{"bearerAuth":[]}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/PublicGuild"}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/users/@me/guild/{guild_id}":{"delete":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"guild_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/users/@me/channels/":{"get":{"security":[{"bearerAuth":[]}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/PublicChannel"}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/users/{user_id}/":{"get":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"user_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PublicUser"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/users/{user_id}/channels/":{"post":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"user_id","in":"path"}],"requestBody":{"content":{"application/json":{"schema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PublicChannel"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/users/{user_id}/relationship/":{"get":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"user_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PrivateRelationship"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}},"post":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"user_id","in":"path"}],"requestBody":{"content":{"application/json":{"schema":{"type":"object","properties":{"type":{"anyOf":[{"type":"string","enum":["blocked"]},{"type":"string","enum":["pending"]}]}}}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PrivateRelationship"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}},"delete":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"user_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/guild/":{"post":{"security":[{"bearerAuth":[]}],"requestBody":{"content":{"application/json":{"schema":{"type":"object","properties":{"name":{"type":"string","minLength":1}},"required":["name"]}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PublicGuild"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/guild/{guild_id}/":{"get":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"guild_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PublicGuild"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}},"patch":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"guild_id","in":"path"}],"requestBody":{"content":{"application/json":{"schema":{"type":"object","properties":{"name":{"type":"string"},"summary":{"type":"string"}},"additionalProperties":false}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}},"delete":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"guild_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/guild/{guild_id}/invite":{"post":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"guild_id","in":"path"}],"requestBody":{"content":{"application/json":{"schema":{"type":"object","properties":{"expiry":{"type":"string","format":"date-time"}}}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/guild/{guild_id}/channel/":{"post":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"guild_id","in":"path"}],"requestBody":{"content":{"application/json":{"schema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PublicGuildTextChannel"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/channel/{channel_id}/":{"get":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"channel_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PublicChannel"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}},"patch":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"channel_id","in":"path"}],"requestBody":{"content":{"application/json":{"schema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}},"delete":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"channel_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/channel/{channel_id}/messages/":{"post":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"channel_id","in":"path"}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MessageCreateRequest"}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PublicMessage"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}},"get":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"channel_id","in":"path"},{"schema":{"type":"number","maximum":50,"minimum":1,"default":50},"required":false,"name":"limit","in":"query"},{"schema":{"anyOf":[{"type":"string","enum":["ASC"]},{"type":"string","enum":["DESC"]}],"default":"DESC"},"required":false,"name":"order","in":"query"},{"schema":{"type":"string"},"required":false,"name":"after","in":"query"},{"schema":{"type":"string"},"required":false,"name":"before","in":"query"},{"schema":{"type":"string"},"required":false,"name":"around","in":"query"},{"schema":{"type":"string"},"required":false,"name":"query","in":"query"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/PublicMessage"}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/channel/{channel_id}/call/":{"post":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"channel_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{"token":{"type":"string"},"ip":{"type":"string"}},"required":["token","ip"]}}}},"202":{"description":"","content":{"application/json":{"schema":{"type":"string","enum":["Accepted"]}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/channel/{channel_id}/attachments/":{"post":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"channel_id","in":"path"}],"requestBody":{"content":{"application/json":{"schema":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"Client defined ID for cross referencing attachments to output endpoints. Can be any value. Must be unique"},"name":{"type":"string","description":"User defined file name"},"md5":{"type":"string"},"mime":{"type":"string"},"size":{"type":"number","description":"Size in bytes"},"width":{"type":"number"},"height":{"type":"number"}},"required":["id","name","md5","mime","size"]}}}}},"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"hash":{"type":"string"},"url":{"type":"string"}},"required":["id","hash","url"]}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/channel/{channel_id}/attachments/{hash}":{"get":{"parameters":[{"schema":{"type":"string"},"required":true,"name":"hash","in":"path"},{"schema":{"type":"string"},"required":true,"name":"channel_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}},"/channel/{channel_id}/messages/{message_id}/":{"get":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"channel_id","in":"path"},{"schema":{"type":"string"},"required":true,"name":"message_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"$ref":"#/components/schemas/PublicMessage"}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}},"delete":{"security":[{"bearerAuth":[]}],"parameters":[{"schema":{"type":"string"},"required":true,"name":"channel_id","in":"path"},{"schema":{"type":"string"},"required":true,"name":"message_id","in":"path"}],"responses":{"200":{"description":"","content":{"application/json":{"schema":{"type":"object","properties":{}}}}},"400":{"$ref":"#/components/responses/BadRequest"},"401":{"$ref":"#/components/responses/Unauthorised"},"404":{"$ref":"#/components/responses/NotFound"},"500":{"$ref":"#/components/responses/InternalServerError"}}}}},"webhooks":{}}
+{
+	"openapi": "3.1.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Client to Server API"
+	},
+	"servers": [
+		{
+			"url": "https://chat.understars.dev"
+		}
+	],
+	"components": {
+		"securitySchemes": {
+			"bearerAuth": {
+				"type": "http",
+				"scheme": "bearer",
+				"bearerFormat": "JWT"
+			}
+		},
+		"responses": {
+			"BadRequest": {
+				"description": "Bad request",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/HttpError"
+						}
+					}
+				}
+			},
+			"NotFound": {
+				"description": "The requested resource was not found",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/HttpError"
+						}
+					}
+				}
+			},
+			"Unauthorised": {
+				"description": "Unauthorised",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/HttpError"
+						}
+					}
+				}
+			},
+			"InternalServerError": {
+				"description": "Internal server error",
+				"content": {
+					"application/json": {
+						"schema": {
+							"$ref": "#/components/schemas/HttpError"
+						}
+					}
+				}
+			}
+		},
+		"schemas": {
+			"HttpError": {
+				"type": "object",
+				"properties": {
+					"message": {
+						"type": "string"
+					},
+					"code": {
+						"type": "number"
+					},
+					"detail": {
+						"type": "object",
+						"properties": {
+							"body": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"message": {
+											"type": "string"
+										},
+										"code": {
+											"type": "string"
+										},
+										"path": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										}
+									},
+									"required": [
+										"message",
+										"code",
+										"path"
+									]
+								}
+							},
+							"param": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"message": {
+											"type": "string"
+										},
+										"code": {
+											"type": "string"
+										},
+										"path": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										}
+									},
+									"required": [
+										"message",
+										"code",
+										"path"
+									]
+								}
+							},
+							"query": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"message": {
+											"type": "string"
+										},
+										"code": {
+											"type": "string"
+										},
+										"path": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											}
+										}
+									},
+									"required": [
+										"message",
+										"code",
+										"path"
+									]
+								}
+							}
+						}
+					}
+				},
+				"required": [
+					"message",
+					"code"
+				]
+			},
+			"ActorMention": {
+				"type": "string",
+				"pattern": "^.*@.*$"
+			},
+			"PublicUser": {
+				"type": "object",
+				"properties": {
+					"mention": {
+						"$ref": "#/components/schemas/ActorMention"
+					},
+					"name": {
+						"type": "string"
+					},
+					"summary": {
+						"type": "string"
+					},
+					"display_name": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"mention",
+					"name",
+					"summary",
+					"display_name"
+				]
+			},
+			"PrivateUser": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/PublicUser"
+					},
+					{
+						"type": "object",
+						"properties": {
+							"email": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"email"
+						]
+					}
+				]
+			},
+			"PublicGuildTextChannel": {
+				"type": "object",
+				"properties": {
+					"mention": {
+						"$ref": "#/components/schemas/ActorMention"
+					},
+					"name": {
+						"type": "string"
+					},
+					"guild": {
+						"$ref": "#/components/schemas/ActorMention"
+					}
+				},
+				"required": [
+					"mention",
+					"name"
+				]
+			},
+			"PublicRole": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string",
+						"format": "uuid"
+					},
+					"name": {
+						"type": "string"
+					},
+					"allow": {
+						"type": "array",
+						"items": {
+							"type": "number"
+						}
+					},
+					"deny": {
+						"type": "array",
+						"items": {
+							"type": "number"
+						}
+					},
+					"guild": {
+						"$ref": "#/components/schemas/ActorMention"
+					}
+				},
+				"required": [
+					"id",
+					"name",
+					"allow",
+					"deny",
+					"guild"
+				]
+			},
+			"PublicGuild": {
+				"type": "object",
+				"properties": {
+					"mention": {
+						"$ref": "#/components/schemas/ActorMention"
+					},
+					"name": {
+						"type": "string"
+					},
+					"channels": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/PublicGuildTextChannel"
+						}
+					},
+					"roles": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/PublicRole"
+						}
+					}
+				},
+				"required": [
+					"mention",
+					"name"
+				]
+			},
+			"PublicChannel": {
+				"type": "object",
+				"properties": {
+					"mention": {
+						"$ref": "#/components/schemas/ActorMention"
+					},
+					"name": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"mention",
+					"name"
+				]
+			},
+			"PrivateRelationship": {
+				"type": "object",
+				"properties": {
+					"created": {
+						"type": "string"
+					},
+					"user": {
+						"$ref": "#/components/schemas/PublicUser"
+					},
+					"type": {
+						"type": "integer",
+						"enum": [
+							0,
+							1,
+							2
+						]
+					}
+				},
+				"required": [
+					"created",
+					"user",
+					"type"
+				]
+			},
+			"PublicAttachment": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"hash": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					},
+					"size": {
+						"type": "number"
+					},
+					"width": {
+						"type": [
+							"number",
+							"null"
+						]
+					},
+					"height": {
+						"type": [
+							"number",
+							"null"
+						]
+					}
+				},
+				"required": [
+					"name",
+					"hash",
+					"type",
+					"size"
+				]
+			},
+			"PublicMessage": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string",
+						"format": "uuid"
+					},
+					"content": {
+						"type": "string"
+					},
+					"published": {
+						"type": "string"
+					},
+					"updated": {
+						"type": "string"
+					},
+					"author_id": {
+						"type": "string"
+					},
+					"channel_id": {
+						"type": "string"
+					},
+					"files": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/PublicAttachment"
+						}
+					}
+				},
+				"required": [
+					"id",
+					"content",
+					"published",
+					"updated",
+					"author_id",
+					"channel_id",
+					"files"
+				]
+			},
+			"MessageCreateRequest": {
+				"type": "object",
+				"properties": {
+					"content": {
+						"type": "string"
+					},
+					"files": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"name": {
+									"type": "string"
+								},
+								"hash": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"name",
+								"hash"
+							]
+						}
+					}
+				},
+				"minProperties": 1
+			}
+		},
+		"parameters": {}
+	},
+	"paths": {
+		"/upload/": {
+			"put": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"upload"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"required": true,
+						"name": "t",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/auth/register": {
+			"post": {
+				"tags": [
+					"auth"
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"username": {
+										"type": "string"
+									},
+									"password": {
+										"type": "string"
+									},
+									"email": {
+										"type": "string"
+									},
+									"invite": {
+										"type": "string",
+										"description": "Instance registration invite"
+									}
+								},
+								"required": [
+									"username",
+									"password"
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"token": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"token"
+									]
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/auth/login": {
+			"post": {
+				"tags": [
+					"auth"
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"username": {
+										"type": "string"
+									},
+									"password": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"username",
+									"password"
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"token": {
+											"type": "string"
+										},
+										"user": {
+											"$ref": "#/components/schemas/PublicUser"
+										}
+									},
+									"required": [
+										"token",
+										"user"
+									]
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/invite/{invite_code}": {
+			"post": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"invite"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"required": true,
+						"name": "invite_code",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			},
+			"delete": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"invite"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"required": true,
+						"name": "invite_code",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/users/@me/": {
+			"get": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"users"
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PrivateUser"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			},
+			"patch": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"users"
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"display_name": {
+										"type": "string"
+									},
+									"summary": {
+										"type": "string"
+									},
+									"current_password": {
+										"type": "string"
+									},
+									"password": {
+										"type": "string"
+									},
+									"email": {
+										"type": "string",
+										"format": "email"
+									}
+								},
+								"additionalProperties": false
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/users/@me/guild/": {
+			"get": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"users"
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/PublicGuild"
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/users/@me/guild/{guild_id}": {
+			"delete": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"users"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"required": true,
+						"name": "guild_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/users/@me/channels/": {
+			"get": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"users"
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/PublicChannel"
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/users/{user_id}/": {
+			"get": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"users"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "user_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PublicUser"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/users/{user_id}/channels/": {
+			"post": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"users"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "user_id",
+						"in": "path"
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"name"
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PublicChannel"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/users/{user_id}/relationship/": {
+			"get": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"users"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "user_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PrivateRelationship"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			},
+			"post": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"users"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "user_id",
+						"in": "path"
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"type": {
+										"anyOf": [
+											{
+												"type": "string",
+												"enum": [
+													"blocked"
+												]
+											},
+											{
+												"type": "string",
+												"enum": [
+													"pending"
+												]
+											}
+										]
+									}
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PrivateRelationship"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			},
+			"delete": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"users"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "user_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/guild/": {
+			"post": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"guild"
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"type": "string",
+										"minLength": 1
+									}
+								},
+								"required": [
+									"name"
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PublicGuild"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/guild/{guild_id}/": {
+			"get": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"guild"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "guild_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PublicGuild"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			},
+			"patch": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"guild"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "guild_id",
+						"in": "path"
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"type": "string"
+									},
+									"summary": {
+										"type": "string"
+									}
+								},
+								"additionalProperties": false
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			},
+			"delete": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"guild"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "guild_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/guild/{guild_id}/invite": {
+			"post": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"guild"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "guild_id",
+						"in": "path"
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"expiry": {
+										"type": "string",
+										"format": "date-time"
+									}
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/guild/{guild_id}/channel/": {
+			"post": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"guild"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "guild_id",
+						"in": "path"
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"name"
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PublicGuildTextChannel"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/channel/{channel_id}/": {
+			"get": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"channel"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "channel_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PublicChannel"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			},
+			"patch": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"channel"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "channel_id",
+						"in": "path"
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"name"
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			},
+			"delete": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"channel"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "channel_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/channel/{channel_id}/messages/": {
+			"post": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"channel"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "channel_id",
+						"in": "path"
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/MessageCreateRequest"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PublicMessage"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			},
+			"get": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"channel"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "channel_id",
+						"in": "path"
+					},
+					{
+						"schema": {
+							"type": "number",
+							"maximum": 50,
+							"minimum": 1,
+							"default": 50
+						},
+						"required": false,
+						"name": "limit",
+						"in": "query"
+					},
+					{
+						"schema": {
+							"anyOf": [
+								{
+									"type": "string",
+									"enum": [
+										"ASC"
+									]
+								},
+								{
+									"type": "string",
+									"enum": [
+										"DESC"
+									]
+								}
+							],
+							"default": "DESC"
+						},
+						"required": false,
+						"name": "order",
+						"in": "query"
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"required": false,
+						"name": "after",
+						"in": "query"
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"required": false,
+						"name": "before",
+						"in": "query"
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"required": false,
+						"name": "around",
+						"in": "query"
+					},
+					{
+						"schema": {
+							"type": "string"
+						},
+						"required": false,
+						"name": "query",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/PublicMessage"
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/channel/{channel_id}/call/": {
+			"post": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"channel"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "channel_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"token": {
+											"type": "string"
+										},
+										"ip": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"token",
+										"ip"
+									]
+								}
+							}
+						}
+					},
+					"202": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string",
+									"enum": [
+										"Accepted"
+									]
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/channel/{channel_id}/attachments/": {
+			"post": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"channel"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "channel_id",
+						"in": "path"
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"id": {
+											"type": "string",
+											"description": "Client defined ID for cross referencing attachments to output endpoints. Can be any value. Must be unique"
+										},
+										"name": {
+											"type": "string",
+											"description": "User defined file name"
+										},
+										"md5": {
+											"type": "string"
+										},
+										"mime": {
+											"type": "string"
+										},
+										"size": {
+											"type": "number",
+											"description": "Size in bytes"
+										},
+										"width": {
+											"type": "number"
+										},
+										"height": {
+											"type": "number"
+										}
+									},
+									"required": [
+										"id",
+										"name",
+										"md5",
+										"mime",
+										"size"
+									]
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"id": {
+												"type": "string"
+											},
+											"hash": {
+												"type": "string"
+											},
+											"url": {
+												"type": "string"
+											}
+										},
+										"required": [
+											"id",
+											"hash",
+											"url"
+										]
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/channel/{channel_id}/attachments/{hash}": {
+			"get": {
+				"tags": [
+					"channel"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string"
+						},
+						"required": true,
+						"name": "hash",
+						"in": "path"
+					},
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "channel_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		},
+		"/channel/{channel_id}/messages/{message_id}/": {
+			"get": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"channel"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "channel_id",
+						"in": "path"
+					},
+					{
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						},
+						"required": true,
+						"name": "message_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PublicMessage"
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			},
+			"delete": {
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"tags": [
+					"channel"
+				],
+				"parameters": [
+					{
+						"schema": {
+							"$ref": "#/components/schemas/ActorMention"
+						},
+						"required": true,
+						"name": "channel_id",
+						"in": "path"
+					},
+					{
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						},
+						"required": true,
+						"name": "message_id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {}
+								}
+							}
+						}
+					},
+					"400": {
+						"$ref": "#/components/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/components/responses/Unauthorised"
+					},
+					"404": {
+						"$ref": "#/components/responses/NotFound"
+					},
+					"500": {
+						"$ref": "#/components/responses/InternalServerError"
+					}
+				}
+			}
+		}
+	},
+	"webhooks": {}
+}

--- a/assets/client.json
+++ b/assets/client.json
@@ -200,7 +200,7 @@
 					}
 				]
 			},
-			"PublicGuildTextChannel": {
+			"PublicChannel": {
 				"type": "object",
 				"properties": {
 					"mention": {
@@ -208,14 +208,26 @@
 					},
 					"name": {
 						"type": "string"
-					},
-					"guild": {
-						"$ref": "#/components/schemas/ActorMention"
 					}
 				},
 				"required": [
 					"mention",
 					"name"
+				]
+			},
+			"PublicGuildTextChannel": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/PublicChannel"
+					},
+					{
+						"type": "object",
+						"properties": {
+							"guild": {
+								"$ref": "#/components/schemas/ActorMention"
+							}
+						}
+					}
 				]
 			},
 			"PublicRole": {
@@ -279,21 +291,6 @@
 					"name"
 				]
 			},
-			"PublicChannel": {
-				"type": "object",
-				"properties": {
-					"mention": {
-						"$ref": "#/components/schemas/ActorMention"
-					},
-					"name": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"mention",
-					"name"
-				]
-			},
 			"PrivateRelationship": {
 				"type": "object",
 				"properties": {
@@ -316,6 +313,31 @@
 					"created",
 					"user",
 					"type"
+				]
+			},
+			"PublicDmChannel": {
+				"allOf": [
+					{
+						"$ref": "#/components/schemas/PublicChannel"
+					},
+					{
+						"type": "object",
+						"properties": {
+							"owner": {
+								"$ref": "#/components/schemas/ActorMention"
+							},
+							"recipients": {
+								"type": "array",
+								"items": {
+									"$ref": "#/components/schemas/ActorMention"
+								}
+							}
+						},
+						"required": [
+							"owner",
+							"recipients"
+						]
+					}
 				]
 			},
 			"PublicAttachment": {
@@ -1547,7 +1569,14 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/PublicChannel"
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/PublicGuildTextChannel"
+										},
+										{
+											"$ref": "#/components/schemas/PublicDmChannel"
+										}
+									]
 								}
 							}
 						}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"typeorm-cursor-pagination": "^0.10.1",
 				"uuid": "^11.0.3",
 				"ws": "^8.18.0",
-				"zod": "^3.24.1"
+				"zod": "^3.25.76"
 			},
 			"devDependencies": {
 				"@ava/typescript": "^5.0.0",
@@ -7550,9 +7550,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.25.64",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
-			"integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"typeorm-cursor-pagination": "^0.10.1",
 		"uuid": "^11.0.3",
 		"ws": "^8.18.0",
-		"zod": "^3.24.1"
+		"zod": "^3.25.76"
 	},
 	"lint-staged": {
 		"*.{ts,js,md}": "npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}"

--- a/src/entity/DMChannel.ts
+++ b/src/entity/DMChannel.ts
@@ -29,7 +29,7 @@ export class DMChannel extends Channel {
 		return {
 			...super.toPublic(),
 
-			owner_id: this.owner.mention,
+			owner: this.owner.mention,
 			recipients: this.recipients.map((x) => x.mention),
 		};
 	}
@@ -51,6 +51,6 @@ export class DMChannel extends Channel {
 }
 
 export type PublicDmChannel = PublicChannel & {
-	owner_id: string;
+	owner: string;
 	recipients: string[];
 };

--- a/src/entity/DMChannel.ts
+++ b/src/entity/DMChannel.ts
@@ -5,8 +5,10 @@ import {
 	ManyToMany,
 	ManyToOne,
 } from "typeorm";
+import z from "zod";
+import { ActorMention } from "../util/activitypub/constants";
 import { DefaultPermissions, type PERMISSION } from "../util/permission";
-import type { PublicChannel } from "./channel";
+import { PublicChannel } from "./channel";
 import { Channel } from "./channel";
 import type { User } from "./user";
 
@@ -51,6 +53,13 @@ export class DMChannel extends Channel {
 }
 
 export type PublicDmChannel = PublicChannel & {
-	owner: string;
-	recipients: string[];
+	owner: ActorMention;
+	recipients: ActorMention[];
 };
+
+export const PublicDmChannel: z.ZodType<PublicDmChannel> = PublicChannel.and(
+	z.object({
+		owner: ActorMention,
+		recipients: ActorMention.array(),
+	}),
+).openapi("PublicDmChannel");

--- a/src/entity/actor.ts
+++ b/src/entity/actor.ts
@@ -1,4 +1,5 @@
 import { Column, CreateDateColumn, Index } from "typeorm";
+import type { ActorMention } from "../util/activitypub/constants";
 import { BaseModel } from "./basemodel";
 
 export abstract class Actor extends BaseModel {
@@ -40,7 +41,7 @@ export abstract class Actor extends BaseModel {
 	@Column({ nullable: true, type: String })
 	public_key: string;
 
-	public get mention() {
+	public get mention(): ActorMention {
 		return `${this.remote_id ?? this.id}@${this.domain}`;
 	}
 
@@ -52,6 +53,7 @@ export abstract class Actor extends BaseModel {
 		return this.toPublic();
 	}
 
+	// TODO: how do I narrow this class so that it does contain remote_address
 	/** Whether or not this actor is controlled by us */
 	public isRemote() {
 		return !!this.remote_address;

--- a/src/entity/channel.ts
+++ b/src/entity/channel.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, TableInheritance } from "typeorm";
 import { z } from "zod";
+import { ActorMention } from "../util/activitypub/constants";
 import { HttpError } from "../util/httperror";
 import type { PERMISSION } from "../util/permission";
 import { Actor } from "./actor";
@@ -13,9 +14,8 @@ export class Channel extends Actor {
 
 	public toPublic(): PublicChannel {
 		return {
-			id: this.remote_id ?? this.id,
+			mention: this.mention,
 			name: this.name,
-			domain: this.domain,
 		};
 	}
 
@@ -39,12 +39,11 @@ export class Channel extends Actor {
 	): Promise<boolean> => false;
 }
 
-export type PublicChannel = Pick<Channel, "id" | "name" | "domain">;
+export type PublicChannel = Pick<Channel, "name" | "mention">;
 
 export const PublicChannel: z.ZodType<PublicChannel> = z
 	.object({
-		id: z.string(),
+		mention: ActorMention,
 		name: z.string(),
-		domain: z.string(),
 	})
 	.openapi("PublicChannel");

--- a/src/entity/guild.ts
+++ b/src/entity/guild.ts
@@ -7,6 +7,7 @@ import {
 	OneToMany,
 } from "typeorm";
 import { z } from "zod";
+import { ActorMention } from "../util/activitypub/constants";
 import { checkPermission } from "../util/checkPermission";
 import { HttpError } from "../util/httperror";
 import type { PERMISSION } from "../util/permission";
@@ -35,9 +36,8 @@ export class Guild extends Actor {
 
 	public toPublic(): PublicGuild {
 		return {
-			id: this.remote_id ?? this.id,
+			mention: this.mention,
 			name: this.name,
-			domain: this.domain,
 
 			channels: this.channels
 				? this.channels.map((x) => x.toPublic())
@@ -74,16 +74,16 @@ export class Guild extends Actor {
 	};
 }
 
-export type PublicGuild = Pick<Guild, "id" | "name" | "domain"> & {
+export type PublicGuild = Pick<Guild, "name"> & {
 	channels?: PublicGuildTextChannel[];
 	roles?: PublicRole[];
+	mention: ActorMention;
 };
 
 export const PublicGuild: z.ZodType<PublicGuild> = z
 	.object({
-		id: z.string(),
+		mention: ActorMention,
 		name: z.string(),
-		domain: z.string(),
 		channels: PublicGuildTextChannel.array().optional(),
 		roles: PublicRole.array().optional(),
 	})

--- a/src/entity/member.ts
+++ b/src/entity/member.ts
@@ -35,7 +35,7 @@ export type PublicMember = Pick<Member, "nickname" | "id"> & {
 };
 
 export const PublicMember: z.ZodType<PublicMember> = z.object({
-	id: z.string().uuid(),
+	id: z.string().uuid(), // TODO: See #79 and #78
 	nickname: z.string(),
 	user: PublicUser,
 	roles: z.string().array(),

--- a/src/entity/message.ts
+++ b/src/entity/message.ts
@@ -80,7 +80,7 @@ export type PublicMessage = Pick<
 
 export const PublicMessage: z.ZodType<PublicMessage> = z
 	.object({
-		id: z.string(),
+		id: z.string().uuid(),
 		content: z.string(),
 		published: z.date(),
 		updated: z.date(),

--- a/src/entity/role.ts
+++ b/src/entity/role.ts
@@ -7,6 +7,7 @@ import {
 	ManyToOne,
 } from "typeorm";
 import { z } from "zod";
+import { ActorMention } from "../util/activitypub/constants";
 import { DefaultPermissions, PERMISSION } from "../util/permission";
 import { BaseModel } from "./basemodel";
 import type { Guild } from "./guild";
@@ -56,7 +57,7 @@ export class Role extends BaseModel {
 		return {
 			id: this.remote_id ?? this.id,
 			name: this.name,
-			guild_id: this.guild?.id,
+			guild: this.guild?.mention,
 			allow: this.allow,
 			deny: this.deny,
 		};
@@ -68,13 +69,15 @@ export class Role extends BaseModel {
 }
 
 export type PublicRole = Pick<Role, "id" | "name" | "allow" | "deny"> & {
-	guild_id?: string;
+	guild?: ActorMention;
 };
 
-export const PublicRole: z.ZodType<PublicRole> = z.object({
-	id: z.string(),
-	name: z.string(),
-	allow: z.number().array(),
-	deny: z.number().array(),
-	guild_id: z.string().optional(),
-});
+export const PublicRole: z.ZodType<Omit<PublicRole, "guild">> = z
+	.object({
+		id: z.string().uuid(),
+		name: z.string(),
+		allow: z.number().array(),
+		deny: z.number().array(),
+		guild: ActorMention,
+	})
+	.openapi("PublicRole");

--- a/src/entity/textChannel.ts
+++ b/src/entity/textChannel.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { ActorMention } from "../util/activitypub/constants";
 import { checkPermission } from "../util/checkPermission";
 import type { PERMISSION } from "../util/permission";
-import { Channel } from "./channel";
+import { Channel, PublicChannel } from "./channel";
 import type { Guild } from "./guild";
 import type { User } from "./user";
 
@@ -38,17 +38,13 @@ export class GuildTextChannel extends Channel {
 	) => checkPermission(user, this.guild, permission);
 }
 
-export type PublicGuildTextChannel = Pick<GuildTextChannel, "name"> & {
+export type PublicGuildTextChannel = PublicChannel & {
 	guild?: ActorMention;
-	mention: ActorMention;
 };
 
-export const PublicGuildTextChannel: z.ZodType<
-	Omit<PublicGuildTextChannel, "guild">
-> = z
-	.object({
-		mention: ActorMention,
-		name: z.string(),
-		guild: ActorMention.optional(),
-	})
-	.openapi("PublicGuildTextChannel");
+export const PublicGuildTextChannel: z.ZodType<PublicGuildTextChannel> =
+	PublicChannel.and(
+		z.object({
+			guild: ActorMention.optional(),
+		}),
+	).openapi("PublicGuildTextChannel");

--- a/src/entity/textChannel.ts
+++ b/src/entity/textChannel.ts
@@ -1,5 +1,6 @@
 import { ChildEntity, Column, ManyToOne, Unique } from "typeorm";
 import { z } from "zod";
+import { ActorMention } from "../util/activitypub/constants";
 import { checkPermission } from "../util/checkPermission";
 import type { PERMISSION } from "../util/permission";
 import { Channel } from "./channel";
@@ -23,7 +24,7 @@ export class GuildTextChannel extends Channel {
 	public toPublic(): PublicGuildTextChannel {
 		return {
 			...super.toPublic(),
-			guild_id: this.guild?.id,
+			guild: this.guild?.mention,
 		};
 	}
 
@@ -37,18 +38,17 @@ export class GuildTextChannel extends Channel {
 	) => checkPermission(user, this.guild, permission);
 }
 
-export type PublicGuildTextChannel = Pick<
-	GuildTextChannel,
-	"id" | "name" | "domain"
-> & {
-	guild_id?: string;
+export type PublicGuildTextChannel = Pick<GuildTextChannel, "name"> & {
+	guild?: ActorMention;
+	mention: ActorMention;
 };
 
-export const PublicGuildTextChannel: z.ZodType<PublicGuildTextChannel> = z
+export const PublicGuildTextChannel: z.ZodType<
+	Omit<PublicGuildTextChannel, "guild">
+> = z
 	.object({
-		id: z.string(),
+		mention: ActorMention,
 		name: z.string(),
-		domain: z.string(),
-		guild_id: z.string().optional(),
+		guild: ActorMention.optional(),
 	})
 	.openapi("PublicGuildTextChannel");

--- a/src/entity/user.ts
+++ b/src/entity/user.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, Index, ManyToOne } from "typeorm";
 import { z } from "zod";
+import { ActorMention } from "../util/activitypub/constants";
 import { Actor } from "./actor";
 import { InstanceInvite } from "./instanceInvite";
 
@@ -42,16 +43,15 @@ export class User extends Actor {
 	@Column({ nullable: true, type: String })
 	summary: string | null;
 
-	public get mention() {
+	public get mention(): ActorMention {
 		return `${this.name}@${this.domain}`;
 	}
 
 	public toPublic = (): PublicUser => {
 		return {
-			id: this.id,
+			mention: this.mention,
 			name: this.name,
 			display_name: this.display_name,
-			domain: this.domain,
 			summary: this.summary,
 		};
 	};
@@ -65,19 +65,17 @@ export class User extends Actor {
 	};
 }
 
-export type PublicUser = Pick<
-	User,
-	"name" | "summary" | "display_name" | "domain" | "id"
->;
+export type PublicUser = Pick<User, "name" | "summary" | "display_name"> & {
+	mention: ActorMention;
+};
 export type PrivateUser = PublicUser & Pick<User, "email">;
 
 export const PublicUser: z.ZodType<PublicUser> = z
 	.object({
-		id: z.string(),
+		mention: ActorMention,
 		name: z.string(),
 		summary: z.string(),
 		display_name: z.string(),
-		domain: z.string(),
 	})
 	.openapi("PublicUser");
 

--- a/src/gateway/handlers/members.ts
+++ b/src/gateway/handlers/members.ts
@@ -117,9 +117,7 @@ export const handleMemberListRoleAdd = async (
 	if (!socket.member_list.channel_id) return; // hm
 
 	// If this event is for a guild that does not contain our channel, ignore it
-	if (
-		!(await channelInGuild(socket.member_list.channel_id, event.guild_id))
-	) {
+	if (!(await channelInGuild(socket.member_list.channel_id, event.guild))) {
 		return;
 	}
 

--- a/src/gateway/handlers/members.ts
+++ b/src/gateway/handlers/members.ts
@@ -2,6 +2,7 @@ import { makeHandler } from ".";
 import { DMChannel } from "../../entity/DMChannel";
 import { GuildTextChannel } from "../../entity/textChannel";
 import { User } from "../../entity/user";
+import type { ActorMention } from "../../util/activitypub/constants";
 import { getDatabase } from "../../util/database";
 import { channelInGuild, getChannel } from "../../util/entity/channel";
 import { listenGatewayEvent } from "../../util/events";
@@ -14,7 +15,7 @@ import type { Websocket } from "../util/websocket";
 export type MembersChunkItem = {
 	name: string;
 	member_id?: string;
-	user_id: string;
+	user_id: ActorMention;
 };
 
 /**
@@ -43,7 +44,7 @@ export const onSubscribeMembers = makeHandler(async function (payload) {
 
 		for (const member of members) {
 			items.push({
-				user_id: member.id, // TODO
+				user_id: member.mention, // TODO
 				name: member.display_name ?? member.name,
 			});
 
@@ -92,7 +93,7 @@ export const onSubscribeMembers = makeHandler(async function (payload) {
 
 			items.push({
 				member_id: member.member_id,
-				user_id: member.user_id,
+				user_id: `${member.name}@${member.user_domain}`,
 				name: member.display_name ?? member.name,
 			});
 		}
@@ -239,6 +240,7 @@ const MEMBERS_QUERY = `
 					"gm"."id" member_id,
 					"r"."id" role_id,
 					"users"."id" user_id,
+					"users"."domain" user_domain,
 					"users"."display_name" display_name,
 					"users"."name" name
 				from guild_members gm
@@ -275,6 +277,7 @@ const getMembers = async (
 		member_id: string;
 		role_id: string;
 		user_id: string;
+		user_domain?: string;
 		display_name: string;
 		name: string;
 	}>

--- a/src/gateway/util/listener.ts
+++ b/src/gateway/util/listener.ts
@@ -1,3 +1,4 @@
+import { splitQualifiedMention } from "../../util/activitypub/util";
 import { channelInGuild } from "../../util/entity/channel";
 import { listenGatewayEvent } from "../../util/events";
 import { createLogger } from "../../util/log";
@@ -42,12 +43,16 @@ export const consume = async (socket: Websocket, payload: GATEWAY_EVENT) => {
 	switch (payload.type) {
 		// TODO: for relationships, see #54
 
-		case "CHANNEL_CREATE":
-			listenEvents(socket, [payload.channel.id]);
+		case "CHANNEL_CREATE": {
+			const { user } = splitQualifiedMention(payload.channel.mention);
+			listenEvents(socket, [user]);
 			break;
-		case "GUILD_CREATE":
-			listenEvents(socket, [payload.guild.id]);
+		}
+		case "GUILD_CREATE": {
+			const { user } = splitQualifiedMention(payload.guild.mention);
+			listenEvents(socket, [user]);
 			break;
+		}
 		case "GUILD_DELETE":
 			// if we leave a guild that we're subscribed to, remove our subscription
 			if (

--- a/src/gateway/util/listener.ts
+++ b/src/gateway/util/listener.ts
@@ -59,7 +59,7 @@ export const consume = async (socket: Websocket, payload: GATEWAY_EVENT) => {
 				!socket.member_list.channel_id ||
 				!(await channelInGuild(
 					socket.member_list.channel_id,
-					payload.guild_id,
+					payload.guild,
 				))
 			)
 				break;
@@ -79,7 +79,7 @@ export const consume = async (socket: Websocket, payload: GATEWAY_EVENT) => {
 		case "CHANNEL_DELETE":
 			// if we're subscribed to this channel, unsub
 
-			if (socket.member_list.channel_id !== payload.channel_id) break;
+			if (socket.member_list.channel_id !== payload.channel) break;
 
 			for (const id in socket.member_list.events) {
 				socket.member_list.events[id]();

--- a/src/gateway/util/validation/receive.ts
+++ b/src/gateway/util/validation/receive.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ActorMention } from "../../../util/activitypub/constants";
 
 export const IDENTIFY = z.object({
 	/** User token to use to login */
@@ -11,7 +12,7 @@ export const HEARTBEAT = z.object({
 
 export const SUBSCRIBE_MEMBERS = z.object({
 	/** Channel mention to subscribe to */
-	channel_id: z.string(),
+	channel_id: ActorMention,
 	/** The range to subscribe to
 	 * @example [0, 100]
 	 */

--- a/src/gateway/util/validation/send.ts
+++ b/src/gateway/util/validation/send.ts
@@ -9,6 +9,7 @@ import type { PublicRole } from "../../../entity/role";
 import type { PrivateSession } from "../../../entity/session";
 import type { PublicGuildTextChannel } from "../../../entity/textChannel";
 import type { PrivateUser } from "../../../entity/user";
+import type { ActorMention } from "../../../util/activitypub/constants";
 import type { MembersChunkItem } from "../../handlers/members";
 
 export type GATEWAY_PAYLOAD = {
@@ -36,7 +37,7 @@ export type MESSAGE_CREATE = {
 export type MESSAGE_DELETE = {
 	type: "MESSAGE_DELETE";
 	message_id: string;
-	channel_id: string;
+	channel_id: ActorMention;
 };
 
 export type CHANNEL_CREATE = {
@@ -51,8 +52,8 @@ export type CHANNEL_UPDATE = {
 
 export type CHANNEL_DELETE = {
 	type: "CHANNEL_DELETE";
-	channel_id: string;
-	guild_id?: string;
+	channel_id: ActorMention;
+	guild_id?: ActorMention;
 };
 
 export type MEDIA_TOKEN_RECEIVED = {
@@ -73,7 +74,7 @@ export type GUILD_UPDATE = {
 
 export type GUILD_DELETE = {
 	type: "GUILD_DELETE";
-	guild_id: string;
+	guild_id: ActorMention;
 };
 
 export type ROLE_CREATE = {
@@ -83,27 +84,27 @@ export type ROLE_CREATE = {
 
 export type ROLE_MEMBER_ADD = {
 	type: "ROLE_MEMBER_ADD";
-	guild_id: string;
+	guild_id: ActorMention;
 	role_id: string;
 	member: PublicMember;
 };
 
 export type ROLE_MEMBER_LEAVE = {
 	type: "ROLE_MEMBER_LEAVE";
-	guild_id: string;
+	guild_id: ActorMention;
 	role_id: string;
-	member_id: string;
+	member_id: ActorMention;
 };
 
 export type MEMBER_LEAVE = {
 	type: "MEMBER_LEAVE";
-	guild_id: string;
-	member_id: string;
+	guild_id: ActorMention;
+	user_id: ActorMention;
 };
 
 export type MEMBER_JOIN = {
 	type: "MEMBER_JOIN";
-	guild_id: string;
+	guild_id: ActorMention;
 	member: PublicMember;
 };
 
@@ -119,7 +120,7 @@ export type RELATIONSHIP_UPDATE = {
 
 export type RELATIONSHIP_DELETE = {
 	type: "RELATIONSHIP_DELETE";
-	user_id: string;
+	user_id: ActorMention;
 };
 
 export type INVITE_CREATE = {

--- a/src/gateway/util/validation/send.ts
+++ b/src/gateway/util/validation/send.ts
@@ -37,7 +37,7 @@ export type MESSAGE_CREATE = {
 export type MESSAGE_DELETE = {
 	type: "MESSAGE_DELETE";
 	message_id: string;
-	channel_id: ActorMention;
+	channel: ActorMention;
 };
 
 export type CHANNEL_CREATE = {
@@ -52,8 +52,8 @@ export type CHANNEL_UPDATE = {
 
 export type CHANNEL_DELETE = {
 	type: "CHANNEL_DELETE";
-	channel_id: ActorMention;
-	guild_id?: ActorMention;
+	channel: ActorMention;
+	guild?: ActorMention;
 };
 
 export type MEDIA_TOKEN_RECEIVED = {
@@ -74,7 +74,7 @@ export type GUILD_UPDATE = {
 
 export type GUILD_DELETE = {
 	type: "GUILD_DELETE";
-	guild_id: ActorMention;
+	guild: ActorMention;
 };
 
 export type ROLE_CREATE = {
@@ -84,27 +84,27 @@ export type ROLE_CREATE = {
 
 export type ROLE_MEMBER_ADD = {
 	type: "ROLE_MEMBER_ADD";
-	guild_id: ActorMention;
+	guild: ActorMention;
 	role_id: string;
 	member: PublicMember;
 };
 
 export type ROLE_MEMBER_LEAVE = {
 	type: "ROLE_MEMBER_LEAVE";
-	guild_id: ActorMention;
+	guild: ActorMention;
 	role_id: string;
-	member_id: ActorMention;
+	member: ActorMention;
 };
 
 export type MEMBER_LEAVE = {
 	type: "MEMBER_LEAVE";
-	guild_id: ActorMention;
-	user_id: ActorMention;
+	guild: ActorMention;
+	user: ActorMention;
 };
 
 export type MEMBER_JOIN = {
 	type: "MEMBER_JOIN";
-	guild_id: ActorMention;
+	guild: ActorMention;
 	member: PublicMember;
 };
 
@@ -120,7 +120,7 @@ export type RELATIONSHIP_UPDATE = {
 
 export type RELATIONSHIP_DELETE = {
 	type: "RELATIONSHIP_DELETE";
-	user_id: ActorMention;
+	user: ActorMention;
 };
 
 export type INVITE_CREATE = {

--- a/src/http/api/channel/#id/call.ts
+++ b/src/http/api/channel/#id/call.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { z } from "zod";
+import { ActorMention } from "../../../../util/activitypub/constants";
 import { config } from "../../../../util/config";
 import { getOrFetchChannel } from "../../../../util/entity/channel";
 import { PERMISSION } from "../../../../util/permission";
@@ -18,7 +19,7 @@ router.post(
 	route(
 		{
 			params: z.object({
-				channel_id: z.string(),
+				channel_id: ActorMention,
 			}),
 			response: MediaTokenResponse,
 			errors: { 202: z.literal("Accepted") },

--- a/src/http/api/channel/#id/index.ts
+++ b/src/http/api/channel/#id/index.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import { Channel, PublicChannel } from "../../../../entity/channel";
 import { GuildTextChannel } from "../../../../entity/textChannel";
+import { ActorMention } from "../../../../util/activitypub/constants";
 import { config } from "../../../../util/config";
 import {
 	getOrFetchChannel,
@@ -15,7 +16,7 @@ import { route } from "../../../../util/route";
 const router = Router({ mergeParams: true });
 
 const params = z.object({
-	channel_id: z.string(),
+	channel_id: ActorMention,
 });
 
 router.get(

--- a/src/http/api/channel/#id/index.ts
+++ b/src/http/api/channel/#id/index.ts
@@ -1,7 +1,11 @@
 import { Router } from "express";
 import { z } from "zod";
-import { Channel, PublicChannel } from "../../../../entity/channel";
-import { GuildTextChannel } from "../../../../entity/textChannel";
+import { PublicDmChannel } from "../../../../entity/DMChannel";
+import { Channel } from "../../../../entity/channel";
+import {
+	GuildTextChannel,
+	PublicGuildTextChannel,
+} from "../../../../entity/textChannel";
 import { ActorMention } from "../../../../util/activitypub/constants";
 import { config } from "../../../../util/config";
 import {
@@ -24,7 +28,7 @@ router.get(
 	route(
 		{
 			params,
-			response: PublicChannel,
+			response: z.union([PublicGuildTextChannel, PublicDmChannel]),
 		},
 		async (req, res) => {
 			const channel = await getOrFetchChannel(req.params.channel_id);

--- a/src/http/api/channel/#id/index.ts
+++ b/src/http/api/channel/#id/index.ts
@@ -87,8 +87,8 @@ router.delete(
 		// after a .remove, the id is made undefined but other properties are not
 		emitGatewayEvent(channel.id, {
 			type: "CHANNEL_DELETE",
-			channel_id: channel.mention,
-			guild_id:
+			channel: channel.mention,
+			guild:
 				channel instanceof GuildTextChannel
 					? channel.guild.mention
 					: undefined,

--- a/src/http/api/channel/#id/messages/#id/index.ts
+++ b/src/http/api/channel/#id/messages/#id/index.ts
@@ -113,7 +113,7 @@ router.delete(
 			emitGatewayEvent(channel.id, {
 				type: "MESSAGE_DELETE",
 				message_id: message.id,
-				channel_id: channel.mention,
+				channel: channel.mention,
 			});
 
 			await message.remove();

--- a/src/http/api/channel/#id/messages/#id/index.ts
+++ b/src/http/api/channel/#id/messages/#id/index.ts
@@ -2,6 +2,7 @@ import { ObjectIsNote } from "activitypub-types";
 import { Router } from "express";
 import { z } from "zod";
 import { Message, PublicMessage } from "../../../../../../entity/message";
+import { ActorMention } from "../../../../../../util/activitypub/constants";
 import { APError } from "../../../../../../util/activitypub/error";
 import { resolveAPObject } from "../../../../../../util/activitypub/resolve";
 import { buildMessageFromAPNote } from "../../../../../../util/activitypub/transformers/message";
@@ -9,12 +10,13 @@ import { getOrFetchChannel } from "../../../../../../util/entity/channel";
 import { emitGatewayEvent } from "../../../../../../util/events";
 import { PERMISSION } from "../../../../../../util/permission";
 import { route } from "../../../../../../util/route";
+import { makeUrl, tryParseUrl } from "../../../../../../util/url";
 
 const router = Router({ mergeParams: true });
 
 const MessageRequestParams = z.object({
-	channel_id: z.string(),
-	message_id: z.string(),
+	channel_id: ActorMention,
+	message_id: z.string().uuid(),
 });
 
 router.get(
@@ -40,7 +42,7 @@ router.get(
 				},
 			});
 
-			if (!message && channel.isRemote()) {
+			if (!message && channel.isRemote() && channel.remote_address) {
 				// If this is a remote channel, fetch the message from them
 				// The remote message may be cached
 
@@ -51,8 +53,12 @@ router.get(
 				// through GET /channel/:id/messages and so the message is already in cache and would've
 				// been hit above. so probably fine?
 				// If you could filter a channels outbox somehow, that would be maybe more portable
-				const messageUrl = `${channel.remote_address}/message/${req.params.message_id}`;
-				const obj = await resolveAPObject(messageUrl);
+				const obj = await resolveAPObject(
+					makeUrl(
+						`/message/${req.params.message_id}`,
+						tryParseUrl(channel.remote_address) as URL,
+					),
+				);
 
 				if (!ObjectIsNote(obj)) {
 					throw new APError("Remote did not return a Note object");
@@ -107,7 +113,7 @@ router.delete(
 			emitGatewayEvent(channel.id, {
 				type: "MESSAGE_DELETE",
 				message_id: message.id,
-				channel_id: channel.id,
+				channel_id: channel.mention,
 			});
 
 			await message.remove();

--- a/src/http/api/channel/#id/messages/index.ts
+++ b/src/http/api/channel/#id/messages/index.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import { Attachment } from "../../../../../entity/attachment";
 import { Message, PublicMessage } from "../../../../../entity/message";
+import { ActorMention } from "../../../../../util/activitypub/constants";
 import { getDatabase } from "../../../../../util/database";
 import { getOrFetchChannel } from "../../../../../util/entity/channel";
 import { handleMessage } from "../../../../../util/entity/message";
@@ -35,7 +36,7 @@ router.post(
 	route(
 		{
 			body: MessageCreate,
-			params: z.object({ channel_id: z.string() }),
+			params: z.object({ channel_id: ActorMention }),
 			response: PublicMessage,
 		},
 		async (req, res) => {
@@ -87,7 +88,7 @@ router.get(
 	route(
 		{
 			params: z.object({
-				channel_id: z.string(),
+				channel_id: ActorMention,
 			}),
 			query: MessageFetchOpts,
 			response: z.array(PublicMessage),

--- a/src/http/api/guild/#id/channel.ts
+++ b/src/http/api/guild/#id/channel.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import { PublicGuildTextChannel } from "../../../../entity/textChannel";
+import { ActorMention } from "../../../../util/activitypub/constants";
 import { createGuildTextChannel } from "../../../../util/entity/channel";
 import { getOrFetchGuild } from "../../../../util/entity/guild";
 import { PERMISSION } from "../../../../util/permission";
@@ -12,7 +13,7 @@ router.post(
 	"/",
 	route(
 		{
-			params: z.object({ guild_id: z.string() }),
+			params: z.object({ guild_id: ActorMention }),
 			body: z.object({ name: z.string() }),
 			response: PublicGuildTextChannel,
 		},

--- a/src/http/api/guild/#id/index.ts
+++ b/src/http/api/guild/#id/index.ts
@@ -90,7 +90,7 @@ router.delete(
 
 			emitGatewayEvent(guild.id, {
 				type: "GUILD_DELETE",
-				guild_id: guild.mention,
+				guild: guild.mention,
 			});
 
 			await guild.remove();

--- a/src/http/api/users/#id/channels.ts
+++ b/src/http/api/users/#id/channels.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { DMChannel } from "../../../../entity/DMChannel";
 import { PublicChannel } from "../../../../entity/channel";
 import { getExternalPathFromActor, sendActivity } from "../../../../sender";
+import { ActorMention } from "../../../../util/activitypub/constants";
 import { buildAPActor } from "../../../../util/activitypub/transformers/actor";
 import { addContext } from "../../../../util/activitypub/util";
 import { createDmChannel } from "../../../../util/entity/channel";
@@ -24,7 +25,7 @@ router.post(
 		{
 			body: DMChannelCreate,
 			params: z.object({
-				user_id: z.string(),
+				user_id: ActorMention,
 			}),
 			response: PublicChannel,
 		},

--- a/src/http/api/users/#id/index.ts
+++ b/src/http/api/users/#id/index.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import { PublicUser } from "../../../../entity/user";
+import { ActorMention } from "../../../../util/activitypub/constants";
 import { getOrFetchUser } from "../../../../util/entity/user";
 import { route } from "../../../../util/route";
 
@@ -11,7 +12,7 @@ router.get(
 	route(
 		{
 			params: z.object({
-				user_id: z.string(),
+				user_id: ActorMention,
 			}),
 			response: PublicUser,
 		},

--- a/src/http/api/users/#id/relationship.ts
+++ b/src/http/api/users/#id/relationship.ts
@@ -5,6 +5,7 @@ import {
 	Relationship,
 } from "../../../../entity/relationship";
 import type { User } from "../../../../entity/user";
+import { ActorMention } from "../../../../util/activitypub/constants";
 import {
 	acceptOrCreateRelationship,
 	fetchRelationship,
@@ -19,7 +20,7 @@ router.get(
 	"/",
 	route(
 		{
-			params: z.object({ user_id: z.string() }),
+			params: z.object({ user_id: ActorMention }),
 			response: PrivateRelationship,
 		},
 		async (req, res) => {
@@ -38,7 +39,7 @@ router.post(
 	"/",
 	route(
 		{
-			params: z.object({ user_id: z.string() }),
+			params: z.object({ user_id: ActorMention }),
 			body: z
 				.object({
 					type: z
@@ -75,7 +76,7 @@ router.delete(
 	"/",
 	route(
 		{
-			params: z.object({ user_id: z.string() }),
+			params: z.object({ user_id: ActorMention }),
 		},
 		async (req, res) => {
 			const { user_id } = req.params;
@@ -98,12 +99,12 @@ router.delete(
 			// can't do it in one call, unfortunately. without some hackery of course
 			emitGatewayEvent(req.user.id, {
 				type: "RELATIONSHIP_DELETE",
-				user_id: to.id,
+				user_id: to.mention,
 			});
 
 			emitGatewayEvent(to.id, {
 				type: "RELATIONSHIP_DELETE",
-				user_id: req.user.id,
+				user_id: req.user.mention,
 			});
 
 			// todo federate

--- a/src/http/api/users/#id/relationship.ts
+++ b/src/http/api/users/#id/relationship.ts
@@ -99,12 +99,12 @@ router.delete(
 			// can't do it in one call, unfortunately. without some hackery of course
 			emitGatewayEvent(req.user.id, {
 				type: "RELATIONSHIP_DELETE",
-				user_id: to.mention,
+				user: to.mention,
 			});
 
 			emitGatewayEvent(to.id, {
 				type: "RELATIONSHIP_DELETE",
-				user_id: req.user.mention,
+				user: req.user.mention,
 			});
 
 			// todo federate

--- a/src/http/api/users/@me/guild.ts
+++ b/src/http/api/users/@me/guild.ts
@@ -69,8 +69,8 @@ router.delete(
 		if (deleted.affected) {
 			emitGatewayEvent(req.params.guild_id, {
 				type: "MEMBER_LEAVE",
-				guild_id: `${mention.user}@${mention.domain}`,
-				user_id: req.user.mention,
+				guild: `${mention.user}@${mention.domain}`,
+				user: req.user.mention,
 			});
 		}
 

--- a/src/http/api/users/@me/guild.ts
+++ b/src/http/api/users/@me/guild.ts
@@ -67,12 +67,10 @@ router.delete(
 			.execute();
 
 		if (deleted.affected) {
-			const member_id: string = deleted.raw[0].id;
-
 			emitGatewayEvent(req.params.guild_id, {
 				type: "MEMBER_LEAVE",
-				guild_id: mention.user,
-				member_id,
+				guild_id: `${mention.user}@${mention.domain}`,
+				user_id: req.user.mention,
 			});
 		}
 

--- a/src/scripts/openapi.ts
+++ b/src/scripts/openapi.ts
@@ -159,6 +159,7 @@ const generateOpenapi = (router: Router, requestContentType: string) => {
 			security: route.requires_auth
 				? [{ [bearerAuth.name]: [] }]
 				: undefined,
+			tags: [route.path.split("/")[1]],
 			request: {
 				params: route.options?.params,
 				// headers: z.object({

--- a/src/scripts/stress/users.ts
+++ b/src/scripts/stress/users.ts
@@ -34,7 +34,7 @@ const GUILD_ID = "01977599-db47-7058-a177-97e6f3e1ea7c";
 			domain: config.federation.webapp_url.hostname,
 		}).save();
 
-		await joinGuild(user.id, guild.id);
+		await joinGuild(user.mention, guild.mention);
 	}
 
 	closeDatabase();

--- a/src/util/activitypub/constants.ts
+++ b/src/util/activitypub/constants.ts
@@ -21,7 +21,18 @@ export const ACTIVITYPUB_FETCH_OPTS: RequestInit = {
 	redirect: "follow",
 };
 
-export type ActorMention = `${string}@${string}`;
+export const ActorMentionRegex = /^.*@.*$/;
+
+export const ActorMention = z
+	.custom<`${string}@${string}`>(
+		(val) => typeof val === "string" && val.match(ActorMentionRegex),
+		{
+			message: "Invalid mention",
+		},
+	)
+	.openapi("ActorMention", { type: "string", pattern: "^.*@.*$" });
+
+export type ActorMention = z.infer<typeof ActorMention>;
 
 interface WebfingerLink {
 	rel: string;

--- a/src/util/activitypub/httpsig.ts
+++ b/src/util/activitypub/httpsig.ts
@@ -13,7 +13,7 @@ import { makeInstanceUrl, tryParseUrl } from "../url";
 import { ACTIVITYPUB_FETCH_OPTS } from "./constants";
 import { APError } from "./error";
 import { throwInstanceBlock } from "./instances";
-import { resolveAPObject } from "./resolve";
+import { resolveAPObject, resolveUrlOrObject } from "./resolve";
 import { APObjectIsActor } from "./util";
 
 const Log = createLogger("HTTPSIG");
@@ -112,7 +112,7 @@ export const validateHttpSignature = async (
 
 	// If we don't have a cache, or we should ignore cache
 	if (!actor || noCache) {
-		const remoteActor = await resolveAPObject(actorId);
+		const remoteActor = await resolveAPObject(resolveUrlOrObject(actorId));
 
 		if (!APObjectIsActor(remoteActor))
 			throw new APError("Request was signed by a non-actor object?");

--- a/src/util/activitypub/inbox/handlers/accept.ts
+++ b/src/util/activitypub/inbox/handlers/accept.ts
@@ -8,7 +8,7 @@ import { findActorOfAnyType } from "../../../entity/resolve";
 import { getOrFetchUser } from "../../../entity/user";
 import { emitGatewayEvent } from "../../../events";
 import { APError } from "../../error";
-import { resolveAPObject } from "../../resolve";
+import { resolveAPObject, resolveId, resolveUrlOrObject } from "../../resolve";
 import { splitQualifiedMention } from "../../util";
 
 const AcceptJoin: ActivityHandler = async (activity, target) => {
@@ -31,7 +31,7 @@ const AcceptJoin: ActivityHandler = async (activity, target) => {
 	if (typeof activity.target !== "string")
 		throw new APError("unknown signal server ip format");
 
-	const from = await getOrFetchUser(activity.actor);
+	const from = await getOrFetchUser(resolveId(activity.actor));
 
 	emitGatewayEvent(from.id, {
 		type: "MEDIA_TOKEN_RECEIVED",
@@ -63,7 +63,7 @@ const AcceptFollow: ActivityHandler = async (activity, target) => {
 		const relationship = await acceptRelationship(target, from);
 	} else if (from instanceof Guild) {
 		// A guild join request was accepted
-		await joinGuild(target.id, from.id);
+		await joinGuild(target.mention, from.mention);
 	} else {
 		throw new APError("Don't know how to accept that");
 	}
@@ -78,7 +78,7 @@ export const AcceptActivityHandler: ActivityHandler = async (
 
 	if (Array.isArray(activity.object)) throw new APError("object is array");
 
-	const inner = await resolveAPObject(activity.object);
+	const inner = await resolveAPObject(resolveUrlOrObject(activity.object));
 
 	activity.object = inner;
 

--- a/src/util/activitypub/inbox/handlers/announce.ts
+++ b/src/util/activitypub/inbox/handlers/announce.ts
@@ -4,7 +4,7 @@ import { User } from "../../../../entity/user";
 import { getOrFetchChannel } from "../../../entity/channel";
 import { handleMessage } from "../../../entity/message";
 import { APError } from "../../error";
-import { resolveAPObject } from "../../resolve";
+import { resolveAPObject, resolveId, resolveUrlOrObject } from "../../resolve";
 import { buildMessageFromAPNote } from "../../transformers/message";
 
 /**
@@ -26,7 +26,7 @@ export const AnnounceActivityHandler: ActivityHandler = async (
 	if (Array.isArray(activity.object))
 		throw new APError("Cannot accept Announce with multiple `object`s");
 
-	const inner = await resolveAPObject(activity.object);
+	const inner = await resolveAPObject(resolveUrlOrObject(activity.object));
 
 	if (!ObjectIsNote(inner))
 		throw new APError(`Cannot accept Announce<${inner.type}>`);
@@ -40,7 +40,7 @@ export const AnnounceActivityHandler: ActivityHandler = async (
 	if (typeof activity.actor !== "string")
 		throw new APError("Cannot accept Announce with non-string actor");
 
-	const channel = await getOrFetchChannel(activity.actor);
+	const channel = await getOrFetchChannel(resolveId(activity.actor));
 
 	const message = await buildMessageFromAPNote(inner, channel);
 

--- a/src/util/activitypub/inbox/handlers/create.ts
+++ b/src/util/activitypub/inbox/handlers/create.ts
@@ -16,7 +16,7 @@ import { getOrFetchUser } from "../../../entity/user";
 import { emitGatewayEvent } from "../../../events";
 import { PERMISSION } from "../../../permission";
 import { APError } from "../../error";
-import { resolveAPObject, resolveId } from "../../resolve";
+import { resolveAPObject, resolveId, resolveUrlOrObject } from "../../resolve";
 import { buildMessageFromAPNote } from "../../transformers/message";
 
 /**
@@ -47,7 +47,7 @@ const CreateAtUser = async (activity: APActivity, target: User) => {
 			"Cannot accept Create activity with multiple `object`s",
 		);
 
-	const inner = await resolveAPObject(activity.object);
+	const inner = await resolveAPObject(resolveUrlOrObject(activity.object));
 
 	if (ObjectIsGroup(inner)) {
 		// Create<Group> at User
@@ -94,7 +94,7 @@ const CreateAtUser = async (activity: APActivity, target: User) => {
 		if (!channel) {
 			// make it since it doesn't exist
 			channel = await createDmChannel(
-				sender.display_name, // TODO
+				`${sender.name} and ${target.name}`,
 				sender,
 				[target],
 			);
@@ -124,7 +124,7 @@ const CreateAtChannel = async (activity: APActivity, target: Channel) => {
 			"Cannot accept Create activity with multiple `object`s",
 		);
 
-	const inner = await resolveAPObject(activity.object);
+	const inner = await resolveAPObject(resolveUrlOrObject(activity.object));
 
 	if (!ObjectIsNote(inner))
 		throw new APError(`Cannot accept Create<${inner.type}>`);

--- a/src/util/activitypub/inbox/handlers/follow.ts
+++ b/src/util/activitypub/inbox/handlers/follow.ts
@@ -12,6 +12,7 @@ import { acceptOrCreateRelationship } from "../../../entity/relationship";
 import { getOrFetchUser } from "../../../entity/user";
 import { makeInstanceUrl } from "../../../url";
 import { APError } from "../../error";
+import { resolveId } from "../../resolve";
 import { addContext, splitQualifiedMention } from "../../util";
 
 export const FollowActivityHandler: ActivityHandler = async (
@@ -24,7 +25,7 @@ export const FollowActivityHandler: ActivityHandler = async (
 	if (typeof from !== "string")
 		throw new APError("Follow activity must have single actor");
 
-	const actor = await getOrFetchUser(from);
+	const actor = await getOrFetchUser(resolveId(from));
 	if (!actor.collections?.inbox)
 		throw new APError("Received follow from actor without inbox");
 
@@ -58,7 +59,7 @@ export const FollowActivityHandler: ActivityHandler = async (
 			relations: { guild: true },
 		});
 
-		await joinGuild(actor.id, invite.guild.id);
+		await joinGuild(actor.mention, invite.guild.mention);
 	} else throw new APError("Cannot accept follows for this target");
 
 	const accept: APAccept = addContext({

--- a/src/util/activitypub/inbox/handlers/join.ts
+++ b/src/util/activitypub/inbox/handlers/join.ts
@@ -8,6 +8,7 @@ import { PERMISSION } from "../../../permission";
 import { makeInstanceUrl } from "../../../url";
 import { generateMediaToken } from "../../../voice";
 import { APError } from "../../error";
+import { resolveId } from "../../resolve";
 import { addContext } from "../../util";
 
 export const JoinActivityHandler: ActivityHandler = async (
@@ -33,7 +34,7 @@ export const JoinActivityHandler: ActivityHandler = async (
 	if (makeInstanceUrl(getExternalPathFromActor(target)) !== activity.object)
 		throw new APError("Object and target mismatch?");
 
-	const user = await getOrFetchUser(activity.actor);
+	const user = await getOrFetchUser(resolveId(activity.actor));
 
 	await target.throwPermission(user, [
 		PERMISSION.VIEW_CHANNEL,

--- a/src/util/activitypub/inbox/handlers/undo.ts
+++ b/src/util/activitypub/inbox/handlers/undo.ts
@@ -1,7 +1,7 @@
 import { ActivityIsFollow } from "activitypub-types";
 import type { ActivityHandler } from ".";
 import { APError } from "../../error";
-import { resolveAPObject } from "../../resolve";
+import { resolveAPObject, resolveUrlOrObject } from "../../resolve";
 
 export const UndoActivityHandler: ActivityHandler = async (
 	activity,
@@ -11,7 +11,7 @@ export const UndoActivityHandler: ActivityHandler = async (
 	if (Array.isArray(activity.object))
 		throw new APError("Don't know how to undo multiple objects");
 
-	const inner = await resolveAPObject(activity.object);
+	const inner = await resolveAPObject(resolveUrlOrObject(activity.object));
 
 	if (!ActivityIsFollow(inner))
 		throw new APError("only know how to undo follow");

--- a/src/util/activitypub/resolve.ts
+++ b/src/util/activitypub/resolve.ts
@@ -14,6 +14,8 @@ import { createLogger } from "../log";
 import { tryParseUrl } from "../url";
 import {
 	ACTIVITY_JSON_ACCEPT,
+	type ActorMention,
+	ActorMentionRegex,
 	USER_AGENT,
 	WebfingerResponse,
 } from "./constants";
@@ -26,11 +28,11 @@ import { splitQualifiedMention } from "./util";
 const Log = createLogger("ap:resolve");
 
 export const resolveAPObject = async <T extends AnyAPObject>(
-	data: string | T,
+	data: URL | T,
 	noCache = false,
 ): Promise<T> => {
 	// we were already given an object
-	if (typeof data !== "string") {
+	if (!(data instanceof URL)) {
 		if (!noCache)
 			await ApCache.create({
 				id: data.id,
@@ -40,25 +42,23 @@ export const resolveAPObject = async <T extends AnyAPObject>(
 	}
 
 	if (!noCache) {
-		const cache = await ApCache.findOne({ where: { id: data } });
+		const cache = await ApCache.findOne({ where: { id: data.toString() } });
 		if (cache) return cache.raw as T;
 	}
 
-	const url = new URL(data);
+	throwInstanceBlock(data);
 
-	throwInstanceBlock(url);
-
-	if (url.hostname === config.federation.instance_url.hostname)
+	if (data.hostname === config.federation.instance_url.hostname)
 		throw new APError(
 			"Tried to resolve remote resource, but we are the remote!",
 		);
 
-	Log.verbose(`Fetching from remote ${url}`);
+	Log.verbose(`Fetching from remote ${data}`);
 
 	// sign the request
-	const signed = signWithHttpSignature(url.toString(), "get", InstanceActor);
+	const signed = signWithHttpSignature(data.toString(), "get", InstanceActor);
 
-	const res = await fetch(url, signed);
+	const res = await fetch(data, signed);
 
 	if (!res.ok)
 		throw new APError(
@@ -72,14 +72,14 @@ export const resolveAPObject = async <T extends AnyAPObject>(
 	const header = res.headers.get("content-type");
 	if (!header || !ACTIVITY_JSON_ACCEPT.find((x) => header.includes(x)))
 		throw new APError(
-			`Fetched resource ${url} did not return an activitypub/jsonld content type`,
+			`Fetched resource ${data} did not return an activitypub/jsonld content type`,
 		);
 
 	if (!hasAPContext(json)) throw new APError("Object is not APObject");
 
 	if (!json.id) throw new APError("Object does not have an ID");
 
-	if (url.origin !== new URL(json.id).origin)
+	if (data.origin !== new URL(json.id).origin)
 		throw new APError(
 			"Object ID origin does not match origin of requested url",
 		);
@@ -93,16 +93,55 @@ export const resolveAPObject = async <T extends AnyAPObject>(
 	return json as T;
 };
 
+/**
+ * Get an ID from a string or AP object
+ * @param prop A mention or URL string, or an AP object
+ * @returns ActorMention or URL
+ * @throws APError if could not resolve to an ID
+ */
 export const resolveId = (prop: string | AnyAPObject | APLink) => {
-	if (typeof prop === "string" && !!tryParseUrl(prop)) return prop;
-	if (typeof prop === "string")
-		throw new APError(`Cannot resolve ${prop} to a URL ID`);
-	if ("id" in prop && prop.id) return prop.id;
-	throw new APError(`Cannot resolve ${prop} to a URL ID`);
+	if (typeof prop === "string") {
+		// this may be a url or actor mention
+		const url = tryParseUrl(prop);
+
+		// it was a url
+		if (url) return url;
+
+		// it was a mention
+		if (prop.match(ActorMentionRegex)) return prop as ActorMention;
+	}
+
+	// we were given an object
+
+	if (typeof prop !== "string" && "id" in prop && prop.id) {
+		// the object has an ID, is it a valid URL?
+		const url = tryParseUrl(prop.id);
+		if (url) return url;
+	}
+
+	// we couldn't find an URL ID or mention
+	throw new APError(`Cannot resolve ${prop} to a URL or mention`);
+};
+
+/**
+ * Returns either a URL or Object
+ * @param prop A mention or URL string, or an AP object
+ */
+export const resolveUrlOrObject = <T extends AnyAPObject | APLink>(
+	prop: string | AnyAPObject | APLink,
+) => {
+	if (typeof prop === "string") {
+		const url = tryParseUrl(prop);
+		if (url) return url;
+	} else {
+		return prop as T;
+	}
+
+	throw new APError(`Could not resolve ${prop} to an URL or object`);
 };
 
 const doWebfingerOrFindTemplate = async (
-	lookup: string,
+	lookup: string | URL,
 ): Promise<WebfingerResponse> => {
 	const { domain } = splitQualifiedMention(lookup);
 
@@ -166,8 +205,11 @@ const doWebfingerOrFindTemplate = async (
 	return WebfingerResponse.parse(await res.json());
 };
 
+export type AcctURI = `acct:${ActorMention}`;
+export type InviteURI = `invite:${ActorMention}`;
+
 export const resolveWebfinger = async (
-	lookup: string,
+	lookup: ActorMention | AcctURI | InviteURI | URL,
 ): Promise<AnyAPObject> => {
 	Log.verbose(`Performing webfinger lookup ${lookup}`);
 
@@ -182,7 +224,7 @@ export const resolveWebfinger = async (
 	if (!link || !link.href)
 		throw new APError(".well-known did not contain rel=self href");
 
-	return await resolveAPObject<AnyAPObject>(link.href);
+	return await resolveAPObject<AnyAPObject>(link);
 };
 
 /**
@@ -200,7 +242,7 @@ export const resolveCollectionEntries = async (
 
 	const ret: Array<string | AnyAPObject> = [];
 
-	const parent = await resolveAPObject(collection.toString());
+	const parent = await resolveAPObject(collection);
 
 	if (!ObjectIsCollection(parent))
 		throw new APError(`${collection} is not a collection`);

--- a/src/util/activitypub/util.ts
+++ b/src/util/activitypub/util.ts
@@ -10,24 +10,31 @@ import {
 	ObjectIsGroup,
 	ObjectIsPerson,
 } from "activitypub-types";
+import { tryParseUrl } from "../url";
 import { APError } from "./error";
 
-export const splitQualifiedMention = (lookup: string) => {
+/**
+ * Split a string or URL into the domain and user parts. For URLs, this is NOT the username auth part
+ * @param lookup Either an ActorMention or URL string
+ * @returns Domain and user parts of input
+ */
+export const splitQualifiedMention = (lookup: string | URL) => {
 	let domain: string;
 	let user: string;
-	if (lookup.includes("@")) {
+	if (typeof lookup === "string" && lookup.includes("@")) {
 		// lookup a @handle@domain
 		if (lookup[0] === "@") lookup = lookup.slice(1);
 		[user, domain] = lookup.split("@");
 	} else {
 		// lookup was a URL ( hopefully )
-		try {
-			const url = new URL(lookup);
-			domain = url.hostname;
-			user = url.pathname.split("/").reverse()[0];
-		} catch (e) {
+
+		const url = tryParseUrl(lookup);
+		if (!url) {
 			throw new APError("Lookup is not valid handle or URL");
 		}
+
+		domain = url.hostname;
+		user = url.pathname.split("/").reverse()[0]; // not great
 	}
 
 	return {

--- a/src/util/entity/channel.ts
+++ b/src/util/entity/channel.ts
@@ -1,7 +1,3 @@
-import crypto from "node:crypto";
-import { promisify } from "node:util";
-const generateKeyPair = promisify(crypto.generateKeyPair);
-
 import {
 	type APActor,
 	type APGroup,
@@ -15,10 +11,12 @@ import { Channel } from "../../entity/channel";
 import { Guild } from "../../entity/guild";
 import { GuildTextChannel } from "../../entity/textChannel";
 import { User } from "../../entity/user";
+import type { ActorMention } from "../activitypub/constants";
 import { APError } from "../activitypub/error";
 import {
 	resolveAPObject,
 	resolveCollectionEntries,
+	resolveId,
 	resolveWebfinger,
 } from "../activitypub/resolve";
 import { splitQualifiedMention } from "../activitypub/util";
@@ -94,8 +92,8 @@ where ch.id = ch2.id and ch."guildId" = $1`;
 	await getDatabase().query(sql, [guild_id]);
 };
 
-export const getChannel = async (lookup: string) => {
-	const mention = splitQualifiedMention(lookup);
+export const getChannel = async (lookup: ActorMention | URL) => {
+	const mention = splitQualifiedMention(resolveId(lookup));
 
 	// TODO: this may break when we have other channel types
 	return await getDatabase()
@@ -125,9 +123,10 @@ export const getChannel = async (lookup: string) => {
 		.getOne();
 };
 
-export const getOrFetchChannel = async (lookup: string | APGroup) => {
-	const id = typeof lookup === "string" ? lookup : lookup.id;
-	if (!id) throw new APError("Cannot fetch channel without ID");
+export const getOrFetchChannel = async (
+	lookup: URL | ActorMention | APGroup,
+) => {
+	const id = resolveId(lookup);
 
 	let channel = await getChannel(id);
 
@@ -152,20 +151,16 @@ export const channelInGuild = async (channel_id: string, guild_id: string) => {
 };
 
 export const createChannelFromRemoteGroup = async (
-	lookup: string | APActor,
+	lookup: ActorMention | URL | APActor,
 ) => {
-	const mention =
-		typeof lookup === "string"
-			? splitQualifiedMention(lookup)
-			: // biome-ignore lint/style/noNonNullAssertion: TODO
-				splitQualifiedMention(lookup.id!);
+	const mention = splitQualifiedMention(resolveId(lookup));
 
 	const obj =
 		typeof lookup === "string"
-			? tryParseUrl(lookup)
+			? await resolveWebfinger(lookup)
+			: lookup instanceof URL
 				? await resolveAPObject(lookup)
-				: await resolveWebfinger(lookup)
-			: lookup;
+				: lookup;
 
 	if (!ObjectIsGroup(obj)) throw new APError("Resolved object is not Group");
 
@@ -230,11 +225,13 @@ export const createChannelFromRemoteGroup = async (
 					(prev, curr) => {
 						const id = typeof curr === "string" ? curr : curr.id;
 						if (id !== obj.attributedTo) {
-							if (
-								typeof curr === "string" ||
-								ObjectIsPerson(curr)
-							)
+							if (typeof curr === "string") {
+								const url = tryParseUrl(curr);
+								if (!url) return prev;
+								prev.push(getOrFetchUser(url));
+							} else if (ObjectIsPerson(curr)) {
 								prev.push(getOrFetchUser(curr));
+							}
 						}
 
 						return prev;
@@ -257,14 +254,19 @@ export const createChannelFromRemoteGroup = async (
 const resolveChannelOwner = async (lookup: string) => {
 	// is lookup on our domain?
 
-	const mention = splitQualifiedMention(lookup);
+	const id = resolveId(lookup);
+
+	const mention = splitQualifiedMention(id);
 
 	const actor = await findActorOfAnyType(mention.user, mention.domain);
 	if (actor) return actor;
 
 	// otherwise, do a remote lookup
 
-	const obj = await resolveAPObject(lookup);
+	const obj =
+		id instanceof URL
+			? await resolveAPObject(id)
+			: await resolveWebfinger(id);
 
 	if (ObjectIsPerson(obj)) return await createUserForRemotePerson(obj);
 

--- a/src/util/entity/guild.ts
+++ b/src/util/entity/guild.ts
@@ -97,7 +97,7 @@ export const joinGuild = async (
 
 	emitGatewayEvent(guild_id, {
 		type: "MEMBER_JOIN",
-		guild_id,
+		guild: guild_id,
 		member: member.toPublic(),
 	});
 
@@ -189,7 +189,7 @@ export const createGuild = async (name: string, owner: User) => {
 	emitGatewayEvent(guild.id, {
 		type: "ROLE_MEMBER_ADD",
 		role_id: everyone.id,
-		guild_id: guild.mention,
+		guild: guild.mention,
 		member: member.toPublic(),
 	});
 

--- a/src/util/entity/guild.ts
+++ b/src/util/entity/guild.ts
@@ -9,11 +9,13 @@ import { Guild } from "../../entity/guild";
 import { Member } from "../../entity/member";
 import { Role } from "../../entity/role";
 import type { GuildTextChannel } from "../../entity/textChannel";
-import { User } from "../../entity/user";
+import type { User } from "../../entity/user";
+import type { ActorMention } from "../activitypub/constants";
 import { APError } from "../activitypub/error";
 import {
 	resolveAPObject,
 	resolveCollectionEntries,
+	resolveId,
 	resolveWebfinger,
 } from "../activitypub/resolve";
 import { ObjectIsRole } from "../activitypub/transformers/role";
@@ -76,10 +78,21 @@ export const getGuilds = (user_id: string) =>
 		})
 		.getMany();
 
-export const joinGuild = async (user_id: string, guild_id: string) => {
+export const joinGuild = async (
+	user_id: ActorMention,
+	guild_id: ActorMention,
+) => {
+	const guild = await getOrFetchGuild(guild_id);
+	const user = await getOrFetchUser(user_id);
+
+	// if (user.domain !== config.federation.instance_url.origin)
+	// 	throw new APError("Tried to join a guild for a user we don't control?");
+
 	const member = await Member.create({
-		user: User.create({ id: user_id }),
-		roles: [Role.create({ id: guild_id })],
+		user,
+
+		// if this guild id does not exist, we should get an error when we try to save
+		roles: [Role.create({ id: guild.id })],
 	}).save();
 
 	emitGatewayEvent(guild_id, {
@@ -90,18 +103,16 @@ export const joinGuild = async (user_id: string, guild_id: string) => {
 
 	emitGatewayEvent(user_id, {
 		type: "GUILD_CREATE",
-		guild: (
-			await Guild.findOneOrFail({ where: { id: guild_id } })
-		).toPublic(),
+		guild: guild.toPublic(),
 	});
 
 	return member;
 };
 
-export const getOrFetchGuild = async (lookup: string | APOrganization) => {
-	const id = typeof lookup === "string" ? lookup : lookup.id;
-
-	if (!id) throw new APError("Cannot fetch guild without ID");
+export const getOrFetchGuild = async (
+	lookup: URL | ActorMention | APOrganization,
+) => {
+	const id = resolveId(lookup);
 
 	const mention = splitQualifiedMention(id);
 
@@ -124,7 +135,7 @@ export const getOrFetchGuild = async (lookup: string | APOrganization) => {
 
 	if (!guild && config.federation.enabled) {
 		// fetch from remote instance
-		guild = await createGuildFromRemoteOrg(lookup);
+		guild = await createGuildFromRemoteOrg(resolveId(lookup));
 		await guild.save();
 	} else if (!guild) {
 		throw new APError("Guild could not be found", 404);
@@ -178,26 +189,24 @@ export const createGuild = async (name: string, owner: User) => {
 	emitGatewayEvent(guild.id, {
 		type: "ROLE_MEMBER_ADD",
 		role_id: everyone.id,
-		guild_id: guild.id,
+		guild_id: guild.mention,
 		member: member.toPublic(),
 	});
 
 	return guild;
 };
 
-export const createGuildFromRemoteOrg = async (lookup: string | APActor) => {
-	const mention =
-		typeof lookup === "string"
-			? splitQualifiedMention(lookup)
-			: // biome-ignore lint/style/noNonNullAssertion: <explanation>
-				splitQualifiedMention(lookup.id!);
+export const createGuildFromRemoteOrg = async (
+	lookup: ActorMention | URL | APActor,
+) => {
+	const mention = splitQualifiedMention(resolveId(lookup));
 
 	const obj =
 		typeof lookup === "string"
-			? tryParseUrl(lookup)
+			? await resolveWebfinger(lookup)
+			: lookup instanceof URL
 				? await resolveAPObject(lookup)
-				: await resolveWebfinger(lookup)
-			: lookup;
+				: lookup;
 
 	if (!ObjectIsOrganization(obj))
 		throw new APError("Resolved object is not Organization");
@@ -227,7 +236,7 @@ export const createGuildFromRemoteOrg = async (lookup: string | APActor) => {
 		remote_id: mention.user,
 
 		name: obj.name,
-		owner: await getOrFetchUser(obj.attributedTo),
+		owner: await getOrFetchUser(resolveId(obj.attributedTo)),
 
 		// to be assigned later
 		channels: [],
@@ -253,7 +262,11 @@ export const createGuildFromRemoteOrg = async (lookup: string | APActor) => {
 			await resolveCollectionEntries(new URL(obj.following.toString()))
 		).reduce(
 			(prev, curr) => {
-				if (typeof curr === "string" || ObjectIsGroup(curr)) {
+				if (typeof curr === "string") {
+					const url = tryParseUrl(curr);
+					if (!url) return prev;
+					prev.push(getOrFetchChannel(url));
+				} else if (ObjectIsGroup(curr)) {
 					prev.push(getOrFetchChannel(curr));
 				}
 				return prev;

--- a/src/util/entity/member.ts
+++ b/src/util/entity/member.ts
@@ -1,16 +1,16 @@
 import type { APPerson } from "activitypub-types";
 import { Member } from "../../entity/member";
 import type { User } from "../../entity/user";
-import { APError } from "../activitypub/error";
+import type { ActorMention } from "../activitypub/constants";
+import { resolveId } from "../activitypub/resolve";
 import { splitQualifiedMention } from "../activitypub/util";
 import { HttpError } from "../httperror";
 import { getOrFetchUser } from "./user";
 
-export const getOrFetchMember = async (lookup: string | APPerson) => {
-	const id = typeof lookup === "string" ? lookup : lookup.id;
-	if (!id) throw new APError("Member id is undefined");
-
-	const mention = splitQualifiedMention(id);
+export const getOrFetchMember = async (
+	lookup: ActorMention | URL | APPerson,
+) => {
+	const mention = splitQualifiedMention(resolveId(lookup));
 
 	const member = await Member.findOne({
 		where: {

--- a/src/util/entity/role.ts
+++ b/src/util/entity/role.ts
@@ -5,22 +5,25 @@ import { APError } from "../activitypub/error";
 import {
 	resolveAPObject,
 	resolveCollectionEntries,
+	resolveId,
+	resolveWebfinger,
 } from "../activitypub/resolve";
-import type { APRole } from "../activitypub/transformers/role";
+import { type APRole, ObjectIsRole } from "../activitypub/transformers/role";
 import { splitQualifiedMention } from "../activitypub/util";
+import { tryParseUrl } from "../url";
 import { getOrFetchGuild } from "./guild";
 import { getOrFetchMember } from "./member";
 
 export const createRoleFromRemote = async (lookup: string | APRole) => {
-	const mention =
-		typeof lookup === "string"
-			? splitQualifiedMention(lookup)
-			: // biome-ignore lint/style/noNonNullAssertion: <explanation>
-				splitQualifiedMention(lookup.id!);
+	const id = resolveId(lookup);
+	const mention = splitQualifiedMention(id);
 
-	const obj = await resolveAPObject(lookup);
+	const obj =
+		id instanceof URL
+			? await resolveAPObject(id)
+			: await resolveWebfinger(id);
 
-	if (obj.type !== "Role")
+	if (!ObjectIsRole(obj))
 		throw new APError(`Expected role but found ${obj.type}`);
 
 	if (!obj.attributedTo || typeof obj.attributedTo !== "string")
@@ -32,14 +35,18 @@ export const createRoleFromRemote = async (lookup: string | APRole) => {
 		allow: obj.allow,
 		deny: obj.deny,
 		position: obj.position,
-		guild: await getOrFetchGuild(obj.attributedTo),
+		guild: await getOrFetchGuild(resolveId(obj.attributedTo)),
 		members: [], // to be fetched later
 	});
 
 	const members = await Promise.all([
 		...(await resolveCollectionEntries(new URL(obj.members))).reduce(
 			(prev, curr) => {
-				if (typeof curr === "string" || ObjectIsPerson(curr)) {
+				if (typeof curr === "string") {
+					const url = tryParseUrl(curr);
+					if (!url) return prev;
+					prev.push(getOrFetchMember(url));
+				} else if (ObjectIsPerson(curr)) {
 					prev.push(getOrFetchMember(curr));
 				}
 				return prev;

--- a/src/util/url.ts
+++ b/src/util/url.ts
@@ -1,6 +1,8 @@
 import { config } from "./config";
 
-export const tryParseUrl = (input: string) => {
+export const tryParseUrl = (input: string | URL) => {
+	if (input instanceof URL) return input;
+
 	try {
 		return new URL(input);
 	} catch (e) {
@@ -8,26 +10,26 @@ export const tryParseUrl = (input: string) => {
 	}
 };
 
-const makeUrl = (path: string, base: URL) => {
+export const makeUrl = (path: string, base: URL) => {
 	const url = new URL(base);
 
 	if (path.startsWith("/")) path = path.slice(1);
 
 	url.pathname = `${url.pathname}${url.pathname.endsWith("/") ? "" : "/"}${path}`;
 
-	return url.href;
+	return url;
 };
 
 /**
  * Appends a path to the instance URL
  */
 export const makeInstanceUrl = (path: string) => {
-	return makeUrl(path, config.federation.instance_url);
+	return makeUrl(path, config.federation.instance_url).href;
 };
 
 /**
  * Appends a path to the webapp URL
  */
 export const makeWebappUrl = (path: string) => {
-	return makeUrl(path, config.federation.webapp_url);
+	return makeUrl(path, config.federation.webapp_url).href;
 };

--- a/test/helpers/channel.ts
+++ b/test/helpers/channel.ts
@@ -5,8 +5,11 @@ export const createTestDm = async (
 ) => {
 	const { createDmChannel } = await import("../../src/util/entity/channel");
 	const { getOrFetchUser } = await import("../../src/util/entity/user");
-	const o = await getOrFetchUser(owner);
-	const r = await Promise.all(recipients.map((x) => getOrFetchUser(x)));
+	const { resolveId } = await import("../../src/util/activitypub/resolve");
+	const o = await getOrFetchUser(resolveId(owner));
+	const r = await Promise.all(
+		recipients.map((x) => getOrFetchUser(resolveId(x))),
+	);
 
 	const channel = await createDmChannel(name, o, r);
 

--- a/test/helpers/guild.ts
+++ b/test/helpers/guild.ts
@@ -9,12 +9,17 @@ export const createTestGuild = async (
 	);
 	const { getOrFetchUser } = await import("../../src/util/entity/user");
 
-	const o = await getOrFetchUser(owner);
+	const { resolveId } = await import("../../src/util/activitypub/resolve");
+
+	const o = await getOrFetchUser(resolveId(owner));
 	const guild = await createGuild(name, o);
 
 	await Promise.all(
 		members.map(async (x) =>
-			joinGuild((await getOrFetchUser(x)).id, guild.id),
+			joinGuild(
+				(await getOrFetchUser(resolveId(x))).mention,
+				guild.mention,
+			),
 		),
 	);
 

--- a/test/http/guild.ts
+++ b/test/http/guild.ts
@@ -39,10 +39,14 @@ test("Get as member", async (t) => {
 		"user2@localhost",
 	]);
 	const expected = guild.toPublic();
-	// biome-ignore lint/performance/noDelete:
-	for (const ch of expected.channels || []) delete ch.guild_id;
-	// biome-ignore lint/performance/noDelete:
-	for (const r of expected.roles || []) delete r.guild_id;
+
+	// @ts-ignore
+	// biome-ignore lint/performance/noDelete: remove this field because it's redundant in GET /guild/:id
+	for (const ch of expected.channels || []) delete ch.guild;
+
+	// @ts-ignore
+	// biome-ignore lint/performance/noDelete: remove this field because it's redundant in GET /guild/:id
+	for (const r of expected.roles || []) delete r.guild;
 
 	const res = await request(api.app)
 		.get(`/guild/${guild.mention}`)
@@ -69,11 +73,15 @@ test("Get as non-member", async (t) => {
 	]);
 
 	const guild = await createTestGuild("test guild", "user3@localhost", []);
-	const expected = guild.toPublic();
-	// biome-ignore lint/performance/noDelete:
-	for (const ch of expected.channels || []) delete ch.guild_id;
-	// biome-ignore lint/performance/noDelete:
-	for (const r of expected.roles || []) delete r.guild_id;
+	const expected = { ...guild.toPublic() };
+
+	// @ts-ignore
+	// biome-ignore lint/performance/noDelete: remove this field because it's redundant in GET /guild/:id
+	for (const ch of expected.channels || []) delete ch.guild;
+
+	// @ts-ignore
+	// biome-ignore lint/performance/noDelete: remove this field because it's redundant in GET /guild/:id
+	for (const r of expected.roles || []) delete r.guild;
 
 	const res = await request(api.app)
 		.get(`/guild/${guild.mention}`)


### PR DESCRIPTION
- Replace any client facing usage of UUIDs with mentions if possible
- Add mention validation and stricter type checking where ever possible
- Add tags to openapi

@TheEntropyShard this PR is a breaking change, but it will mostly just a rename

migration will probably just be adding `[id, domain] = mention.split("@")` anywhere you use `id` or `domain`. or the equivalent in Java, of course