### PR TITLE
feat: voice state

### DIFF
--- a/src/entity/voiceState.ts
+++ b/src/entity/voiceState.ts
@@ -1,0 +1,18 @@
+import { BaseEntity, Column, Entity, ManyToOne, PrimaryColumn } from "typeorm";
+import type { Channel } from "./channel";
+import type { User } from "./user";
+
+@Entity("voice_state")
+export class VoiceState extends BaseEntity {
+	@PrimaryColumn()
+	userId: string;
+
+	@ManyToOne("users", { onDelete: "CASCADE" })
+	user: User;
+
+	@ManyToOne("channels", { onDelete: "CASCADE" })
+	channel: Channel;
+
+	@Column({ type: "timestamptz" })
+	joined: Date;
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,4 +1,5 @@
 namespace NodeJS {
+	// biome-ignore lint/correctness/noUnusedVariables: not unused
 	interface ProcessEnv {
 		DANGEROUS_NO_TLS?: string;
 	}

--- a/src/gateway/handlers/identify.ts
+++ b/src/gateway/handlers/identify.ts
@@ -1,6 +1,9 @@
+import { In } from "typeorm";
 import { DMChannel } from "../../entity/DMChannel";
 import { Session } from "../../entity/session";
 import type { User } from "../../entity/user";
+import { VoiceState } from "../../entity/voiceState";
+import type { ActorMention } from "../../util/activitypub/constants";
 import { getDatabase } from "../../util/database";
 import { getGuilds } from "../../util/entity/guild";
 import { fetchRelationships } from "../../util/entity/relationship";
@@ -19,6 +22,8 @@ import { startHeartbeatTimeout } from "./heartbeat";
  * - Build payload and send to user
  */
 export const onIdentify = makeHandler(async function (payload) {
+	clearTimeout(this.auth_timeout);
+
 	let user: User;
 	try {
 		user = await getUserFromToken(payload.token);
@@ -51,13 +56,34 @@ export const onIdentify = makeHandler(async function (payload) {
 
 	this.session = session;
 
-	listenEvents(this, [
-		user,
-		// TODO: for relationships, see #54
-		...dmChannels,
-		...guilds,
-		...guilds.flatMap((x) => x.channels),
-	]);
+	const rawVoiceState: Array<{
+		channel_id: string;
+		channel_domain: string;
+		channel_remote_id?: string;
+		users: ActorMention[];
+	}> = await getDatabase()
+		.getRepository(VoiceState)
+		.createQueryBuilder("voice")
+		.leftJoin("voice.channel", "channel")
+		.leftJoinAndSelect("voice.user", "user")
+		.where("channel.id IN (:...channel_ids)", {
+			channel_ids: dmChannels.map((x) => x.id),
+		})
+		.groupBy("channel.id")
+		.select([
+			"channel.id",
+			"channel.domain",
+			"channel.remote_id",
+			"array_agg(user.id) as users",
+		])
+		.getRawMany();
+
+	const voiceState: Record<ActorMention, ActorMention[]> = {};
+	for (const row of rawVoiceState) {
+		const mention: ActorMention = `${row.channel_remote_id ?? row.channel_id}@${row.channel_domain}`;
+
+		voiceState[mention] = row.users;
+	}
 
 	const ret: READY = {
 		type: "READY",
@@ -66,11 +92,18 @@ export const onIdentify = makeHandler(async function (payload) {
 		channels: dmChannels.map((x) => x.toPublic()),
 		guilds: guilds.map((x) => x.toPublic()),
 		relationships: relationships.map((x) => x.toClient(this.user_id)),
+		voice: voiceState,
 	};
 
 	startHeartbeatTimeout(this);
 
-	clearTimeout(this.auth_timeout);
+	await consume(this, ret);
 
-	return await consume(this, ret);
+	listenEvents(this, [
+		user,
+		// TODO: for relationships, see #54
+		...dmChannels,
+		...guilds,
+		...guilds.flatMap((x) => x.channels),
+	]);
 }, IDENTIFY);

--- a/src/gateway/handlers/identify.ts
+++ b/src/gateway/handlers/identify.ts
@@ -1,4 +1,3 @@
-import { In } from "typeorm";
 import { DMChannel } from "../../entity/DMChannel";
 import { Session } from "../../entity/session";
 import type { User } from "../../entity/user";

--- a/src/gateway/handlers/identify.ts
+++ b/src/gateway/handlers/identify.ts
@@ -60,22 +60,24 @@ export const onIdentify = makeHandler(async function (payload) {
 		channel_domain: string;
 		channel_remote_id?: string;
 		users: ActorMention[];
-	}> = await getDatabase()
-		.getRepository(VoiceState)
-		.createQueryBuilder("voice")
-		.leftJoin("voice.channel", "channel")
-		.leftJoinAndSelect("voice.user", "user")
-		.where("channel.id IN (:...channel_ids)", {
-			channel_ids: dmChannels.map((x) => x.id),
-		})
-		.groupBy("channel.id")
-		.select([
-			"channel.id",
-			"channel.domain",
-			"channel.remote_id",
-			"array_agg(user.id) as users",
-		])
-		.getRawMany();
+	}> = !dmChannels.length
+		? []
+		: await getDatabase()
+				.getRepository(VoiceState)
+				.createQueryBuilder("voice")
+				.leftJoin("voice.channel", "channel")
+				.leftJoinAndSelect("voice.user", "user")
+				.where("channel.id IN (:...channel_ids)", {
+					channel_ids: dmChannels.map((x) => x.id),
+				})
+				.groupBy("channel.id")
+				.select([
+					"channel.id",
+					"channel.domain",
+					"channel.remote_id",
+					"array_agg(user.id) as users",
+				])
+				.getRawMany();
 
 	const voiceState: Record<ActorMention, ActorMention[]> = {};
 	for (const row of rawVoiceState) {

--- a/src/gateway/handlers/index.ts
+++ b/src/gateway/handlers/index.ts
@@ -3,10 +3,12 @@ import { onHeartbeat } from "./heartbeat";
 import { onIdentify } from "./identify";
 import { onSubscribeMembers } from "./members";
 import { onTyping } from "./typing";
+import { onVoiceQuery } from "./voiceQuery";
 
 export const handlers = {
 	identify: onIdentify,
 	heartbeat: onHeartbeat,
 	members: onSubscribeMembers,
 	typing: onTyping,
+	voices: onVoiceQuery,
 } as Record<string, GatewayMessageHandler<unknown>>;

--- a/src/gateway/handlers/voiceQuery.ts
+++ b/src/gateway/handlers/voiceQuery.ts
@@ -1,0 +1,71 @@
+import { In } from "typeorm";
+import { User } from "../../entity/user";
+import { VoiceState } from "../../entity/voiceState";
+import type { ActorMention } from "../../util/activitypub/constants";
+import { getDatabase } from "../../util/database";
+import { getOrFetchGuild } from "../../util/entity/guild";
+import { PERMISSION } from "../../util/permission";
+import { makeHandler } from "../util/handler";
+import { consume } from "../util/listener";
+import { VOICE_QUERY } from "../util/validation/receive";
+import type { VOICE_STATE } from "../util/validation/send";
+
+export const onVoiceQuery = makeHandler(async function (payload) {
+	const guild = await getOrFetchGuild(payload.guild);
+	if (!guild) throw new Error("Guild does not exist");
+
+	const channels = [];
+
+	for (const channel of guild.channels) {
+		channel.guild = guild;
+
+		if (
+			await channel.checkPermission(
+				User.create({ id: this.user_id }),
+				PERMISSION.VIEW_CHANNEL,
+			)
+		)
+			channels.push(channel);
+	}
+
+	const voiceStates: Array<{
+		channel_id: string;
+		channel_domain: string;
+		channel_remote_id?: string;
+		users: string[];
+	}> = await getDatabase()
+		.getRepository(VoiceState)
+		.createQueryBuilder("voice")
+		.leftJoin("voice.channel", "channel")
+		.leftJoinAndSelect("voice.user", "user")
+		.where("channel.id IN (:...channel_ids)", {
+			channel_ids: channels.map((x) => x.id),
+		})
+		.groupBy("channel.id")
+		.select([
+			"channel.id",
+			"channel.domain",
+			"channel.remote_id",
+			"array_agg(user.id) as users",
+		])
+		.getRawMany();
+
+	const ret: VOICE_STATE = {
+		type: "VOICE_STATE",
+		states: {},
+	};
+
+	for (const row of voiceStates) {
+		const mention: ActorMention = `${row.channel_remote_id ?? row.channel_id}@${row.channel_domain}`;
+
+		ret.states[mention] = (
+			await User.find({
+				where: {
+					id: In(row.users),
+				},
+			})
+		).map((x) => x.toPublic());
+	}
+
+	return await consume(this, ret);
+}, VOICE_QUERY);

--- a/src/gateway/util/validation/receive.ts
+++ b/src/gateway/util/validation/receive.ts
@@ -24,3 +24,7 @@ export const SUBSCRIBE_MEMBERS = z.object({
 export const TYPING = z.object({
 	channel: ActorMention,
 });
+
+export const VOICE_QUERY = z.object({
+	guild: ActorMention,
+});

--- a/src/gateway/util/validation/send.ts
+++ b/src/gateway/util/validation/send.ts
@@ -8,7 +8,7 @@ import type { PrivateRelationship } from "../../../entity/relationship";
 import type { PublicRole } from "../../../entity/role";
 import type { PrivateSession } from "../../../entity/session";
 import type { PublicGuildTextChannel } from "../../../entity/textChannel";
-import type { PrivateUser } from "../../../entity/user";
+import type { PrivateUser, PublicUser } from "../../../entity/user";
 import type { ActorMention } from "../../../util/activitypub/constants";
 import type { MembersChunkItem } from "../../handlers/members";
 
@@ -172,6 +172,18 @@ export type TYPING = {
 	timestamp: number;
 };
 
+export type VOICE_JOIN = {
+	type: "VOICE_JOIN";
+	channel: ActorMention;
+	user: PublicUser;
+};
+
+export type VOICE_LEAVE = {
+	type: "VOICE_LEAVE";
+	channel: ActorMention;
+	user: ActorMention;
+};
+
 export type GATEWAY_EVENT =
 	| MESSAGE_CREATE
 	| MESSAGE_UPDATE
@@ -197,4 +209,6 @@ export type GATEWAY_EVENT =
 	| MEMBERS_CHUNK
 	| READY
 	| HEARTBEAT_ACK
-	| TYPING;
+	| TYPING
+	| VOICE_JOIN
+	| VOICE_LEAVE;

--- a/src/gateway/util/validation/send.ts
+++ b/src/gateway/util/validation/send.ts
@@ -158,6 +158,9 @@ export type READY = {
 	channels: Array<PublicChannel>;
 	guilds: Array<PublicGuild>;
 	relationships: Array<PrivateRelationship>;
+
+	/** channel -> users in voice */
+	voice: Record<ActorMention, ActorMention[]>;
 };
 
 export type HEARTBEAT_ACK = {
@@ -182,6 +185,11 @@ export type VOICE_LEAVE = {
 	type: "VOICE_LEAVE";
 	channel: ActorMention;
 	user: ActorMention;
+};
+
+export type VOICE_STATE = {
+	type: "VOICE_STATE";
+	states: Record<ActorMention, Array<PublicUser>>;
 };
 
 export type GATEWAY_EVENT =
@@ -211,4 +219,5 @@ export type GATEWAY_EVENT =
 	| HEARTBEAT_ACK
 	| TYPING
 	| VOICE_JOIN
-	| VOICE_LEAVE;
+	| VOICE_LEAVE
+	| VOICE_STATE;

--- a/src/media/handlers/identify.ts
+++ b/src/media/handlers/identify.ts
@@ -1,6 +1,7 @@
 import type { Channel } from "../../entity/channel";
 import type { User } from "../../entity/user";
 import { CLOSE_CODES } from "../../gateway/util/codes";
+import { emitGatewayEvent } from "../../util/events";
 import { validateMediaToken } from "../../util/voice";
 import { emitMediaEvent, listenMediaEvent } from "../util/events";
 import { getJanus } from "../util/janus";
@@ -37,6 +38,8 @@ export const onIdentify = makeHandler(async function (payload) {
 		this.room_id = res.room;
 	}
 
+	this.channel_id = channel.mention;
+
 	this.media_handle_id = (await janus.attachHandle()).id;
 
 	await janus.joinRoom(this.media_handle_id, this.room_id, user.mention);
@@ -49,6 +52,12 @@ export const onIdentify = makeHandler(async function (payload) {
 	emitMediaEvent(this.room_id, {
 		type: "PEER_JOINED",
 		user_id: this.user_id,
+	});
+
+	emitGatewayEvent(channel, {
+		type: "VOICE_JOIN",
+		channel: channel.mention,
+		user: user.toPublic(),
 	});
 
 	// Join the horde

--- a/src/media/handlers/identify.ts
+++ b/src/media/handlers/identify.ts
@@ -1,5 +1,6 @@
 import type { Channel } from "../../entity/channel";
 import type { User } from "../../entity/user";
+import { VoiceState } from "../../entity/voiceState";
 import { CLOSE_CODES } from "../../gateway/util/codes";
 import { emitGatewayEvent } from "../../util/events";
 import { validateMediaToken } from "../../util/voice";
@@ -22,7 +23,8 @@ export const onIdentify = makeHandler(async function (payload) {
 		return;
 	}
 
-	this.user_id = user.mention;
+	this.user_mention = user.mention;
+	this.user_id = user.id;
 
 	startHeartbeatTimeout(this);
 
@@ -38,7 +40,8 @@ export const onIdentify = makeHandler(async function (payload) {
 		this.room_id = res.room;
 	}
 
-	this.channel_id = channel.mention;
+	this.channel_id = channel.id;
+	this.channel_mention = channel.mention;
 
 	this.media_handle_id = (await janus.attachHandle()).id;
 
@@ -48,10 +51,12 @@ export const onIdentify = makeHandler(async function (payload) {
 
 	await janus.trickle(this.media_handle_id, payload.candidates);
 
+	this.send({ type: "READY", answer: { jsep: response.jsep } });
+
 	// Notify other users we arrived
 	emitMediaEvent(this.room_id, {
 		type: "PEER_JOINED",
-		user_id: this.user_id,
+		user_id: this.user_mention,
 	});
 
 	emitGatewayEvent(channel, {
@@ -65,5 +70,11 @@ export const onIdentify = makeHandler(async function (payload) {
 		this.send(payload),
 	);
 
-	this.send({ type: "READY", answer: { jsep: response.jsep } });
+	await VoiceState.insert(
+		VoiceState.create({
+			user,
+			channel,
+			joined: new Date(),
+		}),
+	);
 }, IDENTIFY);

--- a/src/media/handlers/identify.ts
+++ b/src/media/handlers/identify.ts
@@ -70,11 +70,12 @@ export const onIdentify = makeHandler(async function (payload) {
 		this.send(payload),
 	);
 
-	await VoiceState.insert(
+	await VoiceState.upsert(
 		VoiceState.create({
 			user,
 			channel,
 			joined: new Date(),
 		}),
+		["userId"],
 	);
 }, IDENTIFY);

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -2,6 +2,7 @@ import type { EventEmitter } from "node:events";
 import http from "node:http";
 import ws from "ws";
 import { initDatabase } from "../util/database";
+import { initRabbitMQ } from "../util/events";
 import { createLogger } from "../util/log";
 import { onConnection } from "./socket/connection";
 import { initJanus } from "./util/janus";
@@ -29,6 +30,8 @@ export class MediaGatewayServer {
 		});
 
 		await initDatabase();
+
+		await initRabbitMQ(false);
 
 		try {
 			await initJanus();

--- a/src/media/socket/close.ts
+++ b/src/media/socket/close.ts
@@ -1,4 +1,6 @@
 import type { CloseEvent } from "ws";
+import { Channel } from "../../entity/channel";
+import { emitGatewayEvent } from "../../util/events";
 import { createLogger } from "../../util/log";
 import { emitMediaEvent } from "../util/events";
 import { getJanus } from "../util/janus";
@@ -21,9 +23,16 @@ export async function onClose(this: MediaSocket, event: CloseEvent) {
 	this.events?.();
 
 	// Notify others
-	if (this.room_id)
+	if (this.room_id && this.channel_id) {
 		emitMediaEvent(this.room_id, {
 			type: "PEER_LEFT",
 			user_id: this.user_id,
 		});
+
+		emitGatewayEvent(Channel.create({ id: this.channel_id }), {
+			type: "VOICE_LEAVE",
+			user: this.user_id,
+			channel: this.channel_id,
+		});
+	}
 }

--- a/src/media/socket/close.ts
+++ b/src/media/socket/close.ts
@@ -1,5 +1,6 @@
 import type { CloseEvent } from "ws";
 import { Channel } from "../../entity/channel";
+import { VoiceState } from "../../entity/voiceState";
 import { emitGatewayEvent } from "../../util/events";
 import { createLogger } from "../../util/log";
 import { emitMediaEvent } from "../util/events";
@@ -23,16 +24,18 @@ export async function onClose(this: MediaSocket, event: CloseEvent) {
 	this.events?.();
 
 	// Notify others
-	if (this.room_id && this.channel_id) {
+	if (this.room_id && this.channel_id && this.channel_mention) {
 		emitMediaEvent(this.room_id, {
 			type: "PEER_LEFT",
-			user_id: this.user_id,
+			user_id: this.user_mention,
 		});
 
 		emitGatewayEvent(Channel.create({ id: this.channel_id }), {
 			type: "VOICE_LEAVE",
-			user: this.user_id,
-			channel: this.channel_id,
+			user: this.user_mention,
+			channel: this.channel_mention,
 		});
 	}
+
+	await VoiceState.delete({ userId: this.user_id });
 }

--- a/src/media/util/validation/send.ts
+++ b/src/media/util/validation/send.ts
@@ -1,3 +1,5 @@
+import type { ActorMention } from "../../../util/activitypub/constants";
+
 export type HEARTBEAT_ACK = {
 	// The expected sequence number
 	type: "HEARTBEAT_ACK";
@@ -10,12 +12,12 @@ export type READY = {
 
 export type PEER_JOINED = {
 	type: "PEER_JOINED";
-	user_id: string;
+	user_id: ActorMention;
 };
 
 export type PEER_LEFT = {
 	type: "PEER_LEFT";
-	user_id: string;
+	user_id: ActorMention;
 };
 
 export type MEDIA_EVENT = HEARTBEAT_ACK | PEER_JOINED | PEER_LEFT | READY;

--- a/src/media/util/websocket.ts
+++ b/src/media/util/websocket.ts
@@ -1,4 +1,5 @@
 import type { WebSocket } from "ws";
+import type { ActorMention } from "../../util/activitypub/constants";
 import type { MEDIA_EVENT } from "./validation/send";
 
 export interface MediaSocket extends Omit<WebSocket, "send"> {
@@ -6,13 +7,15 @@ export interface MediaSocket extends Omit<WebSocket, "send"> {
 
 	room_id?: number;
 
+	channel_id?: ActorMention;
+
 	/** Below is copied from gateway src */
 
 	/** The source IP address of this socket */
 	ip_address: string;
 
 	/** The user ID of this authenticated socket */
-	user_id: string;
+	user_id: ActorMention;
 
 	/** The current sequence/event number for this socket */
 	sequence: number;

--- a/src/media/util/websocket.ts
+++ b/src/media/util/websocket.ts
@@ -7,7 +7,8 @@ export interface MediaSocket extends Omit<WebSocket, "send"> {
 
 	room_id?: number;
 
-	channel_id?: ActorMention;
+	channel_mention?: ActorMention;
+	channel_id?: string;
 
 	/** Below is copied from gateway src */
 
@@ -15,7 +16,8 @@ export interface MediaSocket extends Omit<WebSocket, "send"> {
 	ip_address: string;
 
 	/** The user ID of this authenticated socket */
-	user_id: ActorMention;
+	user_mention: ActorMention;
+	user_id: string;
 
 	/** The current sequence/event number for this socket */
 	sequence: number;

--- a/src/push/worker.ts
+++ b/src/push/worker.ts
@@ -57,7 +57,7 @@ const jobHandler = async (job: Job<PushNotificationJobData>) => {
 			);
 
 			console.log(res);
-		} catch (e) {
+		} catch (_e) {
 			await sub.remove();
 		}
 	}

--- a/src/util/datasource.ts
+++ b/src/util/datasource.ts
@@ -28,6 +28,7 @@ import { UploadsCascade1757588526875 } from "./migration/postgres/1757588526875-
 import { InviteIndex1757745204938 } from "./migration/postgres/1757745204938-inviteIndex";
 import { PushSubscription1758865221251 } from "./migration/postgres/1758865221251-pushSubscription";
 import { MessageNonce1771113785560 } from "./migration/postgres/1771113785560-messageNonce";
+import { VoiceState1778143207892 } from "./migration/postgres/1778143207892-voiceState";
 
 let datasource: DataSource;
 
@@ -102,6 +103,7 @@ export const getDatasource = () => {
 			InviteIndex1757745204938,
 			PushSubscription1758865221251,
 			MessageNonce1771113785560,
+			VoiceState1778143207892,
 		],
 	});
 

--- a/src/util/datasource.ts
+++ b/src/util/datasource.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { DataSource } from "typeorm";
 
 import { ApCache } from "../entity/apcache";
@@ -19,6 +18,7 @@ import { Session } from "../entity/session";
 import { GuildTextChannel } from "../entity/textChannel";
 import { LocalUpload } from "../entity/upload";
 import { User } from "../entity/user";
+import { VoiceState } from "../entity/voiceState";
 import { config } from "./config";
 import { LocalUpload1749945089530 } from "./migration/postgres/1749945089530-local_upload";
 import { ChannelOrdering1750057984384 } from "./migration/postgres/1750057984384-channelOrdering";
@@ -83,6 +83,7 @@ export const getDatasource = () => {
 			GuildTextChannel,
 			LocalUpload,
 			User,
+			VoiceState,
 		],
 
 		migrations: [

--- a/src/util/migration/postgres/1778143207892-voiceState.ts
+++ b/src/util/migration/postgres/1778143207892-voiceState.ts
@@ -1,0 +1,27 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class VoiceState1778143207892 implements MigrationInterface {
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE TABLE "voice_state" ("userId" uuid NOT NULL, "joined" TIMESTAMP WITH TIME ZONE NOT NULL, "channelId" uuid, CONSTRAINT "PK_74d65d75dd58f8ffcd87f392a48" PRIMARY KEY ("userId"))`,
+		);
+
+		await queryRunner.query(
+			`ALTER TABLE "voice_state" ADD CONSTRAINT "FK_74d65d75dd58f8ffcd87f392a48" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+		);
+
+		await queryRunner.query(
+			`ALTER TABLE "voice_state" ADD CONSTRAINT "FK_f2479042534c9e412f85304d386" FOREIGN KEY ("channelId") REFERENCES "channels"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`ALTER TABLE "voice_state" DROP CONSTRAINT "FK_74d65d75dd58f8ffcd87f392a48"`,
+		);
+		await queryRunner.query(
+			`ALTER TABLE "voice_state" DROP CONSTRAINT "FK_f2479042534c9e412f85304d386"`,
+		);
+		await queryRunner.query(`DROP TABLE "voice_state"`);
+	}
+}

--- a/src/util/migration/postgres/1778143207892-voiceState.ts
+++ b/src/util/migration/postgres/1778143207892-voiceState.ts
@@ -1,6 +1,8 @@
 import type { MigrationInterface, QueryRunner } from "typeorm";
 
 export class VoiceState1778143207892 implements MigrationInterface {
+	name = "VoiceState1778143207892";
+
 	public async up(queryRunner: QueryRunner): Promise<void> {
 		await queryRunner.query(
 			`CREATE TABLE "voice_state" ("userId" uuid NOT NULL, "joined" TIMESTAMP WITH TIME ZONE NOT NULL, "channelId" uuid, CONSTRAINT "PK_74d65d75dd58f8ffcd87f392a48" PRIMARY KEY ("userId"))`,

--- a/src/util/storage/local.ts
+++ b/src/util/storage/local.ts
@@ -7,7 +7,6 @@ import { Readable } from "node:stream";
 import jwt from "jsonwebtoken";
 import { LocalUpload } from "../../entity/upload";
 import { config } from "../config";
-import { HttpError } from "../httperror";
 import { makeInstanceUrl } from "../url";
 import type { PutFileRequest } from ".";
 


### PR DESCRIPTION
gateway now sends:
- `VOICE_JOIN` to the channel when a user joins a vc
- `VOICE_LEAVE` to the channel when a user leaves a vc
- `VOICE_STATE` when sent `voices` for current voice state of channel

now tracks voice states in db in `voice_state` table